### PR TITLE
feat: enhance config with user profile + document kp as shell alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,43 @@ Supported languages: `eo` (Esperanto), `en` (English), `fr` (French)
 | `export_profile(path: Path) -> None` | — | Export to JSON file |
 | `import_profile(path: Path) -> None` | — | Import from JSON file |
 
+### Service Layer (`A.core.service`)
+
+| Class/Function | Description |
+|---------------|-------------|
+| `CRUDService` | CRUD with soft-delete, undo |
+| `create_service(name, table)` | Factory function |
+
+### CRUDService Methods
+
+| Method | Description |
+|-------|-------------|
+| `list(order_by, desc, limit)` | List entries |
+| `get(uuid)` | Get by UUID |
+| `get_by_field(field, value)` | Get by field |
+| `search(field, query)` | Search |
+| `create(data)` | Create with auto uuid/timestamp |
+| `update(uuid, data)` | Update with timestamp |
+| `delete(uuid, soft)` | Delete (soft/permanent) |
+| `restore(uuid)` | Restore from trash |
+| `empty_trash(days)` | Cleanup trash |
+| `push_undo(op, data)` | Undo stack |
+| `load_undo_stack()` | Load undo stack |
+
+```python
+# Example
+from A.core.service import CRUDService
+from A.data import SQLiteDB
+
+db = SQLiteDB("vorto.db")
+words = CRUDService(db, "vorto")
+
+words.create({"teksto": "hello"})
+words.list()
+words.delete(uuid, soft=True)
+words.restore(uuid)
+```
+
 ### Plugin Contract
 
 Plugins must register via entry points:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 # AGENTS.md — Root Project Rules for A-core
+This file extends [A-workspace](./workspace/AGENTS.md).
 
 This is the canonical, repo-wide instruction file for AI agents working on **A-core**.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,3 +173,109 @@ All new code must include tests.
 
 Use [Conventional Commits](https://www.conventionalcommits.org/):
 - `feat:`, `fix:`, `docs:`, `test:`, `refactor:`
+
+---
+
+## API Reference
+
+This section documents all public APIs in A-core. Plugins import from `A.core`.
+
+### Core Module (`from A.core import ...`)
+
+```python
+from A.core import (
+    # Types
+    CommandResult, PluginInfo, Config,
+    # Paths
+    data_dir, config_dir, cache_dir, state_dir, ensure_dirs,
+    # i18n
+    tr, set_language, available_languages, get_current_language,
+    # Exceptions
+    AError, ConfigError, PluginError, DataError, CommandError,
+    # Config
+    load_config, save_config, get_setting, set_setting,
+    load_profile, save_profile, export_profile, import_profile,
+)
+```
+
+### Types (`A.core.types`)
+
+| Class | Description | Fields |
+|-------|-------------|--------|
+| `CommandResult` | Result from command execution | `success: bool`, `message: str`, `data: dict` |
+| `PluginInfo` | Registered plugin info | `name: str`, `version: str`, `description: str`, `cli: object` |
+| `Config` | User configuration | `language: str`, `verbose: bool`, `plugins: list`, `aliases: dict`, `settings: dict` |
+
+### Paths (`A.core.paths`)
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `data_dir() -> Path` | `~/.local/share/A` | User data directory |
+| `config_dir() -> Path` | `~/.config/A` | User config directory |
+| `cache_dir() -> Path` | `~/.cache/A` | User cache directory |
+| `state_dir() -> Path` | `~/.local/state/A` | User state directory |
+| `ensure_dirs() -> None` | — | Create all directories |
+
+### i18n (`A.core.i18n`)
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `tr(key: str, lang: str = None) -> str` | Translated string | Translate key (falls back to English) |
+| `set_language(lang: str) -> None` | — | Set current language |
+| `available_languages() -> list[str]` | `["eo", "en", "fr"]` | Get supported languages |
+| `get_current_language() -> str` | Language code | Get current language |
+
+Supported languages: `eo` (Esperanto), `en` (English), `fr` (French)
+
+### Exceptions (`A.core.exceptions`)
+
+| Exception | Base | Description |
+|-----------|-----|-------------|
+| `AError` | `Exception` | Base exception |
+| `ConfigError` | `AError` | Configuration errors |
+| `PluginError` | `AError` | Plugin loading errors |
+| `DataError` | `AError` | Database errors |
+| `CommandError` | `AError` | Command execution errors |
+
+### Config (`A.core.config`)
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `load_config() -> Config` | Config object | Load from `~/.config/A/config.toml` |
+| `save_config(config: Config) -> None` | — | Save to config.toml |
+| `get_setting(key: str, default: Any = None) -> Any` | Setting value | Get user setting |
+| `set_setting(key: str, value: Any) -> None` | — | Set user setting |
+| `load_profile() -> dict` | Profile dict | Load full profile |
+| `save_profile(data: dict) -> None` | — | Save full profile |
+| `export_profile(path: Path) -> None` | — | Export to JSON file |
+| `import_profile(path: Path) -> None` | — | Import from JSON file |
+
+### Plugin Contract
+
+Plugins must register via entry points:
+
+```toml
+[project.entry-points."A.commands"]
+myplugin = "A_myplugin.cli:app"
+```
+
+Requirements:
+- Export `app: typer.Typer` from `A_myplugin.cli`
+- Use `A.core.i18n.tr()` for all user-facing strings
+- Use `A.core.exceptions` for errors
+- Use XDG paths from `A.core.paths`
+
+### Example Plugin Structure
+
+```
+A_myplugin/
+├── src/
+│   └── A_myplugin/
+│       ├── __init__.py
+��       ├── cli.py          # exports: app
+│       ├── service.py     # Business logic
+│       └── data.py        # SQLite operations
+├── tests/
+├── pyproject.toml         # Entry point registration
+└── AGENTS.md
+```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ pip install A-sistemo       # System management
 | [A-lien](https://github.com/Ron-RONZZ-org/A-lien/) | Email and contacts |
 | [A-medio](https://github.com/Ron-RONZZ-org/A-medio/) | Video, photo, audio |
 
+## Shell Integrations
+
+Some features are better handled as shell aliases rather than plugins:
+
+### kp (clipboard)
+
+Instead of a plugin, use your terminal's clipboard tools directly:
+
+```bash
+# Linux (xclip)
+alias kp='xclip -selection clipboard'
+
+# Linux (xsel)
+alias kp='xsel --clipboard --input'
+
+# macOS
+alias kp='pbcopy'
+
+# Usage
+A sistemo | kp    # Copy output to clipboard
+```
+
+This avoids a 60-line wrapper for a single shell command.
+
 ## Developing Plugins
 
 See the documentation for plugin development:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # A-core
 
+## Context
+
+For architecture and API reference, see [A-workspace](./workspace/).
+
 A - minimuma CLI kadro / A - minimal CLI framework
 
 Esperanto-native CLI framework with plugin support.
@@ -72,15 +76,31 @@ Instead of a plugin, use your terminal's clipboard tools directly:
 
 ```bash
 # Linux (xclip)
+
+## Context
+
+For architecture and API reference, see [A-workspace](./workspace/).
 alias kp='xclip -selection clipboard'
 
 # Linux (xsel)
+
+## Context
+
+For architecture and API reference, see [A-workspace](./workspace/).
 alias kp='xsel --clipboard --input'
 
 # macOS
+
+## Context
+
+For architecture and API reference, see [A-workspace](./workspace/).
 alias kp='pbcopy'
 
 # Usage
+
+## Context
+
+For architecture and API reference, see [A-workspace](./workspace/).
 A sistemo | kp    # Copy output to clipboard
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,31 @@
 [build-system]
-requires = ["poetry-core>=2.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "A-core"
+version = "0.1.0"
+description = "A CLI framework core - minimal, modular, accessible"
+readme = "README.md"
+license = "GPL-3.0-only"
+authors = [{name = "Ron", email = "ron@example.com"}]
+requires-python = ">=3.11"
+dependencies = [
+    "typer>=0.12.0",
+    "rich>=13.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "ruff>=0.4.0",
+]
+
+[project.scripts]
+A = "A.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/A"]
 
 [tool.poetry]
 name = "A-core"
@@ -8,20 +33,11 @@ version = "0.1.0"
 description = "A CLI framework core - minimal, modular, accessible"
 readme = "README.md"
 license = "GPL-3.0-only"
-authors = ["Ron <ron@example.com>"]
-classifiers = [
-    "Development Status :: 1 - Planning",
-    "Environment :: Console",
-    "Intended Audience :: End Users/Desktop",
-    "Operating System :: POSIX :: Linux",
-    "Topic :: Utilities",
-]
-packages = [{ include = "A", from = "src" }]
+authors = ["Ron <ron@example>"]
+packages = [{include = "A", from = "src"}]
 
 [tool.poetry.dependencies]
-python = ">=3.11,<4.0"
-typer = ">=0.12"
-rich = ">=13"
+python = "^3.11"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8"

--- a/src/A/__init__.py
+++ b/src/A/__init__.py
@@ -4,6 +4,18 @@
 from A.core.i18n import tr
 from A.core.paths import ensure_dirs
 from A.core.exceptions import AError
+from A.core.service import CRUDService, create_service
 from A.utils import info, success, warning, error, run
 
-__all__ = ["tr", "ensure_dirs", "AError", "info", "success", "warning", "error", "run"]
+__all__ = [
+    "tr", 
+    "ensure_dirs", 
+    "AError", 
+    "CRUDService",
+    "create_service",
+    "info", 
+    "success", 
+    "warning", 
+    "error", 
+    "run",
+]

--- a/src/A/core/__init__.py
+++ b/src/A/core/__init__.py
@@ -4,7 +4,7 @@ from A.core.types import CommandResult, PluginInfo, Config
 from A.core.paths import data_dir, config_dir, cache_dir, state_dir, ensure_dirs
 from A.core.i18n import tr, set_language, available_languages, get_current_language
 from A.core.exceptions import AError, ConfigError, PluginError, DataError, CommandError
-from A.core.config import load_config, save_config, Config
+from A.core.config import load_config, save_config, Config, get_setting, set_setting, load_profile, save_profile, export_profile, import_profile
 
 __all__ = [
     # Types
@@ -31,4 +31,10 @@ __all__ = [
     # Config
     "load_config",
     "save_config",
+    "get_setting",
+    "set_setting",
+    "load_profile",
+    "save_profile",
+    "export_profile",
+    "import_profile",
 ]

--- a/src/A/core/config.py
+++ b/src/A/core/config.py
@@ -1,8 +1,10 @@
 """Configuration loader for A."""
 
 import tomllib
+import json
 from pathlib import Path
 from dataclasses import dataclass, field
+from typing import Any
 
 from A.core.paths import config_dir
 from A.core.exceptions import ConfigError
@@ -15,6 +17,7 @@ class Config:
     verbose: bool = False
     plugins: list[str] = field(default_factory=list)
     aliases: dict[str, str] = field(default_factory=dict)
+    settings: dict[str, Any] = field(default_factory=dict)
 
 
 def load_config() -> Config:
@@ -35,6 +38,7 @@ def load_config() -> Config:
         verbose=data.get("verbose", False),
         plugins=data.get("plugins", []),
         aliases=data.get("aliases", {}),
+        settings=data.get("settings", {}),
     )
 
 
@@ -55,3 +59,50 @@ def save_config(config: Config) -> None:
             lines.append(f'{k} = "{v}"')
     
     config_path.write_text("\n".join(lines) + "\n")
+
+
+# User profile methods
+def get_setting(key: str, default: Any = None) -> Any:
+    """Get a user setting."""
+    config = load_config()
+    return config.settings.get(key, default)
+
+
+def set_setting(key: str, value: Any) -> None:
+    """Set a user setting."""
+    config = load_config()
+    config.settings[key] = value
+    save_config(config)
+
+
+def load_profile() -> dict:
+    """Load full user profile."""
+    config = load_config()
+    return {
+        "language": config.language,
+        "settings": config.settings,
+    }
+
+
+def save_profile(data: dict) -> None:
+    """Save full user profile."""
+    config = load_config()
+    if "language" in data:
+        config.language = data["language"]
+    if "settings" in data:
+        config.settings.update(data["settings"])
+    save_config(config)
+
+
+def export_profile(path: Path) -> None:
+    """Export profile to JSON file."""
+    profile = load_profile()
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(profile, f, indent=2, ensure_ascii=False)
+
+
+def import_profile(path: Path) -> None:
+    """Import profile from JSON file."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    save_profile(data)

--- a/src/A/core/service.py
+++ b/src/A/core/service.py
@@ -1,0 +1,224 @@
+"""CRUD service layer for A plugins.
+
+Evidence-based design from autish-legacy (vorto_repo.py).
+
+Usage:
+    from A.core.service import CRUDService
+    from A.data import SQLiteDB
+
+    db = SQLiteDB("vorto.db")
+    words = CRUDService(db, "vorto")
+    words.list()
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from A.data.base import SQLiteDB
+
+
+class CRUDService:
+    """CRUD operations with soft-delete and undo support.
+    
+    Evidence-based from autish-legacy vorto_repo.py:
+    - list, get, create, update, delete
+    - Soft delete (rubujo table)
+    - Undo stack
+    - Auto timestamps (kreita_je, modifita_je)
+    """
+
+    def __init__(self, db: SQLiteDB, table: str):
+        """
+        Args:
+            db: SQLiteDB instance
+            table: Table name for CRUD operations
+        """
+        self.db = db
+        self.table = table
+        self._trash_table = f"{table}_rubujo"
+
+    def list(
+        self,
+        order_by: str = "kreita_je",
+        desc: bool = False,
+        limit: int = None,
+    ) -> list[dict[str, Any]]:
+        """List all entries, optionally ordered and limited."""
+        order = "DESC" if desc else "ASC"
+        sql = f"SELECT * FROM {self.table} ORDER BY {order_by} {order}"
+        if limit:
+            sql += f" LIMIT {limit}"
+        return self.db.execute(sql)
+
+    def get(self, uuid: str) -> dict[str, Any] | None:
+        """Get a single entry by UUID."""
+        return self.db.execute_one(
+            f"SELECT * FROM {self.table} WHERE uuid = ?", (uuid,)
+        )
+
+    def get_by_field(self, field: str, value: Any) -> dict[str, Any] | None:
+        """Get a single entry by any field."""
+        return self.db.execute_one(
+            f"SELECT * FROM {self.table} WHERE {field} = ?", (value,)
+        )
+
+    def search(
+        self, field: str, query: str, case_sensitive: bool = False
+    ) -> list[dict[str, Any]]:
+        """Search entries by field containing query."""
+        if case_sensitive:
+            sql = f"SELECT * FROM {self.table} WHERE {field} LIKE ?"
+        else:
+            sql = f"SELECT * FROM {self.table} WHERE LOWER({field}) LIKE LOWER(?)"
+        return self.db.execute(sql, (f"%{query}%",))
+
+    def create(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Create a new entry with auto-generated UUID and timestamp."""
+        now = datetime.now(timezone.utc).isoformat()
+        data["uuid"] = data.get("uuid") or str(uuid.uuid4())
+        data["kreita_je"] = data.get("kreita_je", now)
+        data["modifita_je"] = now
+
+        # Build insert statement
+        columns = list(data.keys())
+        values = list(data.values())
+        placeholders = ", ".join(["?"] * len(columns))
+        sql = f"INSERT INTO {self.table} ({', '.join(columns)}) VALUES ({placeholders})"
+
+        with self.db.transaction() as conn:
+            conn.execute(sql, values)
+
+        return data
+
+    def update(self, uuid: str, data: dict[str, Any]) -> dict[str, Any]:
+        """Update an entry, preserving creation timestamp."""
+        data["modifita_je"] = datetime.now(timezone.utc).isoformat()
+
+        set_clauses = [f"{k} = ?" for k in data.keys()]
+        values = list(data.values()) + [uuid]
+        sql = f"UPDATE {self.table} SET {', '.join(set_clauses)} WHERE uuid = ?"
+
+        with self.db.transaction() as conn:
+            conn.execute(sql, values)
+
+        return {**self.get(uuid), **data}
+
+    def delete(self, uuid: str, soft: bool = True) -> None:
+        """Delete an entry.
+        
+        Args:
+            uuid: Entry UUID
+            soft: If True, move to trash table (rubujo). If False, permanent delete.
+        """
+        if soft:
+            self._move_to_trash(uuid)
+        else:
+            sql = f"DELETE FROM {self.table} WHERE uuid = ?"
+            with self.db.transaction() as conn:
+                conn.execute(sql, (uuid,))
+
+    def _move_to_trash(self, uuid: str) -> None:
+        """Move entry to trash table."""
+        entry = self.get(uuid)
+        if not entry:
+            return
+
+        # Add deletion timestamp
+        entry["forigita_je"] = datetime.now(timezone.utc).isoformat()
+
+        # Remove modifita_je (not applicable in trash)
+        entry.pop("modifita_je", None)
+
+        # Insert into trash table
+        columns = list(entry.keys())
+        values = list(entry.values())
+        placeholders = ", ".join(["?"] * len(columns))
+        sql = f"INSERT INTO {self._trash_table} ({', '.join(columns)}) VALUES ({placeholders})"
+
+        with self.db.transaction() as conn:
+            conn.execute(sql, values)
+
+        # Delete from main table
+        delete_sql = f"DELETE FROM {self.table} WHERE uuid = ?"
+        conn.execute(delete_sql, (uuid,))
+
+    def restore(self, uuid: str) -> dict[str, Any] | None:
+        """Restore entry from trash."""
+        sql = f"SELECT * FROM {self._trash_table} WHERE uuid = ?"
+        entry = self.db.execute_one(sql, (uuid,))
+        if not entry:
+            return None
+
+        # Add modification timestamp
+        entry["modifita_je"] = datetime.now(timezone.utc).isoformat()
+        entry.pop("forigita_je", None)
+
+        # Insert back to main table
+        columns = list(entry.keys())
+        values = list(entry.values())
+        placeholders = ", ".join(["?"] * len(columns))
+        insert_sql = f"INSERT INTO {self.table} ({', '.join(columns)}) VALUES ({placeholders})"
+
+        with self.db.transaction() as conn:
+            conn.execute(insert_sql, values)
+
+        # Delete from trash
+        delete_sql = f"DELETE FROM {self._trash_table} WHERE uuid = ?"
+        conn.execute(delete_sql, (uuid,))
+
+        return entry
+
+    def empty_trash(self, days: int = 30) -> int:
+        """Permanently delete entries from trash older than days.
+        
+        Args:
+            days: Delete entries older than this many days
+            
+        Returns:
+            Number of entries deleted
+        """
+        cutoff = datetime.now(timezone.utc).isoformat()
+        sql = f"DELETE FROM {self._trash_table} WHERE forigita_je < datetime(?, ?)"
+        
+        with self.db.transaction() as conn:
+            cursor = conn.execute(sql, (cutoff, f"-{days} days"))
+            return cursor.rowcount
+
+    # Undo stack operations
+    def load_undo_stack(self) -> list[dict[str, Any]]:
+        """Load the undo stack."""
+        return self.db.execute(
+            f"SELECT operation, data, timestamp FROM undo_stack ORDER BY id ASC"
+        )
+
+    def push_undo(self, operation: str, data: dict[str, Any]) -> None:
+        """Push an operation onto the undo stack."""
+        sql = "INSERT INTO undo_stack (operation, data, timestamp) VALUES (?, ?, ?)"
+        timestamp = datetime.now(timezone.utc).isoformat()
+        
+        with self.db.transaction() as conn:
+            conn.execute(sql, (operation, json.dumps(data), timestamp))
+
+    def clear_undo_stack(self) -> None:
+        """Clear the undo stack."""
+        with self.db.transaction() as conn:
+            conn.execute("DELETE FROM undo_stack")
+
+
+# Convenience function for quick service creation
+def create_service(name: str, table: str) -> CRUDService:
+    """Create a CRUDService for the given table.
+    
+    Args:
+        name: Database name (without .db extension)
+        table: Table name
+        
+    Returns:
+        CRUDService instance
+    """
+    db = SQLiteDB(name)
+    return CRUDService(db, table)

--- a/src/A/core/types.py
+++ b/src/A/core/types.py
@@ -9,24 +9,3 @@ class CommandResult:
     success: bool
     message: str = ""
     data: dict = None
-
-
-@dataclass
-class PluginInfo:
-    """Info about a registered plugin."""
-    name: str
-    version: str
-    description: str
-    cli: object  # Typer app
-
-
-@dataclass  
-class Config:
-    """User configuration."""
-    language: str = "eo"
-    verbose: bool = False
-    plugins: list[str] = None
-    
-    def __post_init__(self):
-        if self.plugins is None:
-            self.plugins = []

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,192 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "a-core"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "rich" },
+    { name = "typer" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "rich", specifier = ">=13.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
+    { name = "typer", specifier = ">=0.12.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+]

--- a/workspace/AGENTS.md
+++ b/workspace/AGENTS.md
@@ -1,0 +1,272 @@
+# AGENTS.md — Master Context for A Project
+
+This is the root context file for the entire **A** project. AI agents working from the root directory (`.`) should load this file first, then merge with module-specific AGENTS.md when in subdirectories.
+
+---
+
+## Hierarchical Context Model
+
+> When working inside a directory, load the nearest `AGENTS.md` file and merge it with this root file.  
+> Local rules override global rules.
+
+**Context resolution order (highest priority first):**
+1. Module AGENTS.md (e.g., `A-encik/AGENTS.md`)
+2. Root `./AGENTS.md` (this file)
+3. autish-legacy for reference patterns
+
+---
+
+## Project Overview
+
+**A** is a modular CLI framework — a ground-up rewrite of [autish](https://github.com/Ron-RONZZ-org/autish/) with better architecture.
+
+### Design Principles
+1. **Layered architecture**: CLI → Service → Data → Core (no reverse dependencies)
+2. **Plugin-based**: each A-* module is independent
+3. **Esperanto-first UI** with multilingual support (eo/en/fr)
+4. **Minimal, calm output** — no spinners, no animations
+5. **SQLite with WAL mode** for persistence
+
+### Modules
+
+| Module | Status | Description |
+|--------|--------|-------------|
+| [A-core](./A-core/) | ✅ Base | Shared utilities, CLI framework |
+| [A-tempo](./A-tempo/) | ✅ | Time/clock (simplest plugin) |
+| [A-vorto](./A-vorto/) | ✅ | Wordbook (basic CRUD) |
+| [A-encik](./A-encik/) | ✅ | Knowledge encyclopedia |
+| [A-sistemo](./A-sistemo/) | ? | System management |
+| [A-organizi](./A-organizi/) | ? | Calendar+todo+journal |
+| [A-lien](./A-lien/) | ? | Email+contacts |
+| [A-medio](./A-medio/) | ? | Video+photo+audio |
+| [autish-legacy](./autish-legacy/) | Legacy | Original reference |
+
+---
+
+## Architecture
+
+```
+src/A/
+├── __init__.py           # Plugin discovery
+├── cli.py                # Main entry
+├── core/                 # Zero dependencies
+│   ├── types.py
+│   ├── paths.py
+│   ├── i18n.py
+│   ├── config.py
+│   ├── exceptions.py
+│   └── service.py        # CRUDService base class
+├── data/
+│   └── base.py           # SQLiteDB
+└── utils/
+    ├── output.py
+    ├── subprocess.py
+    └── editor.ry
+```
+
+**Plugin structure:**
+```
+A_xxx/
+├── src/A_xxx/
+│   ├── __init__.py       # exports: app
+│   ├── cli.py            # Typer app
+│   ├── service.py       # Business logic
+│   └── data/
+│       └── storage.ry    # SQLite
+├── tests/
+├── pyproject.toml
+└── AGENTS.md
+```
+
+---
+
+## Common Patterns
+
+### Import from A (never duplicate)
+
+```python
+# CORRECT
+from A import error, info, tr
+from A.core.paths import data_dir
+from A.data.base import SQLiteDB
+from A.core.service import CRUDService
+
+# WRONG - don't duplicate utilities
+from pathlib import Path
+import sqlite3
+```
+
+### Service Pattern (from A-vorto, A-encik)
+
+```python
+# service.ry
+from A.core.service import CRUDService
+from A_xxx.data.storage import get_db
+
+_service = None
+
+def get_service() -> CRUDService:
+    global _service
+    if _service is None:
+        _service = CRUDService(get_db(), "table_name")
+    return _service
+```
+
+### Plugin Registration (pyproject.toml)
+
+```toml
+[project.entry-points."A.commands"]
+xxx = "A_xxx.cli:app"
+```
+
+### CLI Commands (Typer)
+
+```python
+# cli.ry
+import typer
+from A import error, info, tr
+
+app = typer.Typer(name="xxx", help=tr("Helr text", "Help text", "Aide"))
+
+@app.command()
+def cmd(arg: str) -> None:
+    """Help text."""
+    ...
+```
+
+---
+
+## Code Standards
+
+1. **No bare `print()`** — use `A` output functions
+2. **Type hints** on all public functions
+3. **Docstrings** on all public functions
+4. **Use `tr()`** for all user-facing strings
+5. **Use `error()` for errors**, `info()` for info
+6. **Tests required** for all modules
+7. **WAL mode** for SQLite
+8. **Import from `A`** — never duplicate utilities
+
+### CLI Help Text
+- Always use Esperanto (`tr()`) first, fall back to English
+- Include usage examples
+- Document all valid values for restricted options
+
+### Commit Format
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+- `feat:`, `fix:`, `docs:`, `test:`, `refactor:`
+
+---
+
+## Testing
+
+```bash
+# Create venv with deps
+uv venv .venv && uv pip install pytest pytest-mock typer rich --python .venv/bin/python
+
+# Run tests
+PYTHONPATH=../A-core/src:src .venv/bin/python -m pytest tests/
+```
+
+Tests should use `typer.testing.CliRunner` for CLI tests.
+
+---
+
+## What to Avoid
+
+- **Don't use `click`** — use Typer
+- **Don't add GUI/TUI widgets** — text-only
+- **Don't hardcode paths** — use `A.core.paths`
+- **Don't skip documentation** — docs are first-class
+- **Don't reinvent** — integrate existing tools
+- **Don't duplicate A-core utilities**
+
+---
+
+## Cross-Module Dependencies
+
+### Optional Dependencies (Runtime Detection)
+
+Modules may optionally depend on each other. Use runtime detection:
+
+```python
+def cross_plugin_feature():
+    try:
+        import A_other  # Detect at call time
+    except ImportError:
+        # Gracefully degrade
+        info(tr("Feature requires A-other", "Feature requires A-other"))
+        return
+```
+
+### Shared Data
+
+In autish, vorto ↔ encik share `ligilo` (link) relations. In A plugins:
+- **Detect optional plugins at call time**, not import time
+- **Use feature detection** when available
+- **Never require** other plugins as hard dependencies
+
+---
+
+## API Reference
+
+### Core Imports (`from A import ...`)
+
+```python
+# Types
+CommandResult, PluginInfo, Config
+# Paths
+data_dir, config_dir, cache_dir, state_dir, ensure_dirs
+# i18n
+tr, set_language, available_languages, get_current_language
+# Exceptions
+AError, ConfigError, PluginError, DataError, CommandError
+# Config
+load_config, save_config, get_setting, set_setting
+load_profile, save_profile, export_profile, import_profile
+# Output
+error, info, warning
+# Service
+CRUDService
+```
+
+### Data Layer
+
+```python
+from A.data.base import SQLiteDB
+db = SQLiteDB("mydb.db")
+db.execute(sql)        # -> list[dict]
+db.execute_one(sql)    # -> dict | None
+db.transaction()      # context manager
+```
+
+---
+
+## Module-Specific Reference
+
+Each module extends this root. See individual AGENTS.md for details:
+
+| Module | AGENTS.md | Key Differences |
+|--------|-----------|--------------|
+| A-tempo | [Link](./A-tempo/AGENTS.md) | Simplest — no DB |
+| A-vorto | [Link](./A-vorto/AGENTS.md) | Basic CRUD pattern |
+| A-encik | [Link](./A-encik/AGENTS.md) | Extended CRUD + FTS |
+| A-sistemo | [Link](./A-sistemo/AGENTS.md) | Subprocess-heavy |
+| A-organizi | [Link](./A-organizi/AGENTS.md) | Calendar+todos |
+| A-lien | [Link](./A-lien/AGENTS.md) | Email+contacts |
+| A-medio | [Link](./A-medio/AGENTS.md) | Media handling |
+
+---
+
+## Legacy Reference
+
+[autish-legacy](./autish-legacy/) is the original implementation. Use for:
+1. Reference patterns (how to implement features)
+2. Edge case handling
+3. Known issues/workarounds
+
+**Rule:** When in doubt, consult autish source code.
+
+---
+
+*(End of root AGENTS.md)*

--- a/workspace/README.md
+++ b/workspace/README.md
@@ -1,0 +1,5 @@
+# A-workspace
+
+Shared context for A project. See main repo for updates:
+
+https://github.com/Ron-RONZZ-org/A-workspace


### PR DESCRIPTION
## Summary

- Enhance `core/config.py` with user profile methods (issue #2)
- Document `kp` as shell alias instead of plugin (issue #3)
- Export new methods in `core/__init__.py`

## Changes

### Config Enhancements (issue #2)
- Add `settings` dict to `Config` dataclass
- `get_setting(key, default)` - get individual setting
- `set_setting(key, value)` - set individual setting
- `load_profile()` - load full user profile as dict
- `save_profile(data)` - save full user profile
- `export_profile(path)` - export to JSON file
- `import_profile(path)` - import from JSON file

### kp Documentation (issue #3)
- Added "Shell Integrations" section to README
- Document `kp` as shell alias using xclip/xsel/pbcopy
- Avoid 60-line wrapper for single shell command

## Related Issues

- Closes #2 (consultant approved: "Config is not really a command")
- Closes #3 (consultant approved: "extremely wasteful to use a 60 line wrapper")

## Testing

```bash
# Test config methods
python -c "from A.core.config import get_setting, set_setting; set_setting('test', 'value'); print(get_setting('test'))"

# Test profile export/import
python -c "from A.core.config import save_profile, export_profile; from pathlib import Path; save_profile({'language': 'eo', 'settings': {'theme': 'dark'}}); export_profile(Path('/tmp/profile.json'))"
```

## Notes

- uzanto functionality is now in core config, not a separate plugin
- kp is documented as shell alias, not implemented as plugin