### PR TITLE
feat: add A modulo module registry system

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -1,0 +1,61 @@
+{
+  "version": 1,
+  "schema_version": "1.0",
+  "updated": "2026-05-03T00:00:00Z",
+  "modules": [
+    {
+      "name": "tempo",
+      "display_name": "Tempo",
+      "pip": "A-tempo",
+      "description": "# Tempo\n\nMontri la nunan lokan daton kaj tagnomon.\n\n* Montri tempon laŭ horzonoj\n* Subtenas UTC-limojn (-12 ĝis +14)\n\n## Installation\n\n```bash\npip install A-tempo\n```\n"
+    },
+    {
+      "name": "vorto",
+      "display_name": "Vorto",
+      "pip": "A-vorto",
+      "description": "# Vorto\n\nVortaro kaj leksikono por A.\n\n* Multlingva vortaro kun tradukoj\n* Frazo-kolekto kaj ekzemploj\n* Etikedoj kaj kategorioj\n* Eksporto/importo kun ĉifrado\n\n## Installation\n\n```bash\npip install A-vorto\n```\n"
+    },
+    {
+      "name": "encik",
+      "display_name": "Encik",
+      "pip": "A-encik",
+      "description": "# Encik\n\nSci-mastruma mikroapo por A.\n\n* Scio-bazo kun semantikaj ligiloj\n* Serĉo laŭ titolo, teksto, kaj semantikaj kondiĉoj\n* Vikipedia-stila grafeo de konceptoj\n* Markdown-aperigo kaj HTML-antaŭvido\n\n## Installation\n\n```bash\npip install A-encik\n```\n"
+    },
+    {
+      "name": "sistemo",
+      "display_name": "Sistemo",
+      "pip": "A-sistemo",
+      "description": "# Sistemo\n\nSistema administrado por A.\n\n* Sistemaj informoj kaj diagnozo\n* Administrado de servoj\n* Monitorado de rimedoj\n\n## Installation\n\n```bash\npip install A-sistemo\n```\n"
+    },
+    {
+      "name": "organizi",
+      "display_name": "Organizi",
+      "pip": "A-organizi",
+      "description": "# Organizi\n\nKalendaro, taskoj, kaj taglibro.\n\n* Eventoj kaj kalendaro\n* Far-listoj (TODO)\n* Tagaj notoj (taglibro)\n* ICS-importo/eksporto\n\n## Installation\n\n```bash\npip install A-organizi\n```\n"
+    },
+    {
+      "name": "lien",
+      "display_name": "Lien",
+      "pip": "A-lien",
+      "description": "# Lien\n\nRetpoŝto kaj kontakt-administrado.\n\n* Retpoŝta sendado/ricevado\n* Kontaktadministrado\n* Ŝlosilvorto-administrado\n\n## Installation\n\n```bash\npip install A-lien\n```\n"
+    },
+    {
+      "name": "medio",
+      "display_name": "Medio",
+      "pip": "A-medio",
+      "description": "# Medio\n\nAŭdvida materiala administrado.\n\n* YouTube-elŝutado\n* Audio/bildo/vidbendo-organizado\n* Metadatumoj\n\n## Installation\n\n```bash\npip install A-medio\n```\n"
+    },
+    {
+      "name": "sekurkopio",
+      "display_name": "Sekurkopio",
+      "pip": "A-sekurkopio",
+      "description": "# Sekurkopio\n\nSekurkopio kaj restaŭrado.\n\n* Rezerva kopio de datumoj kun restic\n* Planitaj sekurkopioj\n* Restaŭrado de dosieroj\n\n## Installation\n\n```bash\npip install A-sekurkopio\n```\n"
+    },
+    {
+      "name": "agento",
+      "display_name": "Agento",
+      "pip": "A-agento",
+      "description": "# Agento\n\nAI-agentoj por A.\n\n* LLM-integrado (OpenAI, Ollama, HuggingFace, DeepSeek)\n* Aŭtomataj taskoj kaj genera enhavo\n* Ŝlosilvarto-administrado por API-oj\n\n## Installation\n\n```bash\npip install A-agento\n```\n"
+    }
+  ]
+}

--- a/src/A/__init__.py
+++ b/src/A/__init__.py
@@ -9,7 +9,9 @@ from A.core.undo import UndoManager, UndoOperation, create_undo_operation
 from A.core.links import Link, get_links_db, add_link, remove_link, get_outgoing, get_incoming, get_links
 from A.core.references import Ref, ResolvedRef, parse_refs, resolve, get_ref_display, clear_ref_cache
 from A.core.ai import get_provider, save_api_key, get_api_key, set_default_provider, get_default_provider, LLMProvider
+from A.core.registry import fetch_registry, search_registry, get_module_info, get_installed_modules
 from A.utils import info, success, warning, error, run, copy_to_clipboard, copy_file
+from A.utils.interactive import select_candidate, confirm_action
 from A.utils.normalize import fold_search_text, normalize_french_ligatures, NORMALIZERS
 from A.core.markdown_parser import render_markdown
 from A.core.markdown_html_view import preview_markdown, preview_html, clear_cache
@@ -44,6 +46,14 @@ __all__ = [
     "UndoManager",
     "UndoOperation",
     "create_undo_operation",
+    # Module registry
+    "fetch_registry",
+    "search_registry",
+    "get_module_info",
+    "get_installed_modules",
+    # Interactive selection
+    "select_candidate",
+    "confirm_action",
     # Links (bidirectional)
     "Link",
     "get_links_db",

--- a/src/A/cli.py
+++ b/src/A/cli.py
@@ -4,11 +4,16 @@ import importlib.metadata
 from typing import Callable
 
 import typer
+from rich.table import Table
+from rich.panel import Panel
 
 from A import tr, tr_multi
 from A.core.paths import ensure_dirs
 from A.core.migration import get_status, migrate_all, migrate_keyring_passwords, MigrationStatus
-from A.utils import info, success, error, warning
+from A.core.registry import fetch_registry, get_module_info, get_installed_modules, search_registry
+from A.core.markdown_parser import render_markdown
+from A.utils import info, success, error, warning, console
+from A.utils.interactive import select_candidate
 
 
 # ── Lazy Plugin Loading ──────────────────────────────────────────────────────
@@ -105,16 +110,13 @@ def main_callback(
 
 @app.command("list")
 def list_cmd() -> None:
-    """Listigi agorditajn komandojn."""
-    names = sorted(_PLUGIN_ENTRY_POINTS.keys())
-
-    if not names:
-        info("Neniuj kromprogramoj instalitaj. Instalu per: pip install A[tempo]")
-        return
-
-    success(f"Agordeblaj komandoj ({len(names)}):")
-    for name in names:
-        info(f"  {name}")
+    """Listigi instalitajn modulojn (malrekomendita)."""
+    warning(tr_multi(
+        "`A list` estas malrekomendita. Uzu `A modulo ls --instalita` anstataŭe.",
+        "`A list` is deprecated. Use `A modulo ls --instalita` instead.",
+        "`A list` est d\u00e9pr\u00e9ci\u00e9. Utilisez `A modulo ls --instalita`.",
+    ))
+    modulo_ls(instalita=True)
 
 
 # ── Migration helpers ─────────────────────────────────────────────────────────
@@ -276,6 +278,247 @@ def _ensure_keyring() -> bool:
         except Exception as e:
             error(f"Instalo malsukcesis: {e}")
             return False
+
+
+# ── Modulo sub-app ────────────────────────────────────────────────────────────
+
+modulo_app = typer.Typer(
+    name="modulo",
+    help=tr_multi(
+        "Moduloj — administrado de A-moduloj",
+        "Modules — A module management",
+        "Modules — gestion des modules A",
+    ),
+    no_args_is_help=True,
+)
+
+
+def _get_first_line(text: str, max_chars: int = 60) -> str:
+    """Extract the first meaningful line from a markdown description."""
+    line = ""
+    for part in text.split("\n"):
+        stripped = part.strip()
+        if stripped and not stripped.startswith("#"):
+            line = stripped
+            break
+    if len(line) > max_chars:
+        line = line[: max_chars - 1] + "\u2026"
+    return line
+
+
+@modulo_app.command("ls")
+def modulo_ls(
+    instalita: bool = typer.Option(
+        False,
+        "--instalita",
+        help=tr_multi(
+            "Montri nur instalitajn modulojn",
+            "Show only installed modules",
+            "Afficher uniquement les modules install\u00e9s",
+        ),
+    ),
+    refresh: bool = typer.Option(
+        False,
+        "--refresh",
+        help=tr_multi(
+            "Refre\u015digi la manifeston de la reto",
+            "Refresh the registry from network",
+            "Actualiser le registre depuis le r\u00e9seau",
+        ),
+    ),
+) -> None:
+    """Listigi modulojn el la registra manifest."""
+    if instalita:
+        modules = get_installed_modules()
+        if not modules:
+            info(tr_multi(
+                "Neniuj moduloj instalitaj.",
+                "No modules installed.",
+                "Aucun module install\u00e9.",
+            ))
+            return
+
+        table = Table(show_header=True, header_style="dim", box=None)
+        table.add_column("#", style="dim", width=3)
+        table.add_column(tr_multi("Nomo", "Name", "Nom"), style="bold")
+        table.add_column(tr_multi("Pip-paketo", "Pip package", "Paquet pip"), style="dim")
+
+        for i, m in enumerate(modules, 1):
+            table.add_row(str(i), m.get("display_name", m["name"]), m.get("pip", ""))
+        console.print(table)
+        return
+
+    # Full list: available + installed
+    data = fetch_registry(refresh=refresh)
+    if data is None:
+        error(tr_multi(
+            "Ne eblas atingi la modul-registron. Kontrolu vian retkonekton.",
+            "Cannot reach the module registry. Check your internet connection.",
+            "Impossible d'atteindre le registre. V\u00e9rifiez votre connexion.",
+        ))
+        raise typer.Exit(1)
+
+    installed_names = {m["name"] for m in get_installed_modules()}
+    all_modules = sorted(data.get("modules", []), key=lambda m: m.get("name", ""))
+
+    table = Table(show_header=True, header_style="dim", box=None)
+    table.add_column("#", style="dim", width=3)
+    table.add_column(tr_multi("Nomo", "Name", "Nom"), style="bold")
+    table.add_column(
+        tr_multi("Priskribo", "Description", "Description"), style="dim"
+    )
+    table.add_column(
+        tr_multi("Stato", "Status", "\u00c9tat"), style="dim", width=12
+    )
+
+    for i, m in enumerate(all_modules, 1):
+        name = m.get("name", "")
+        display = m.get("display_name", name)
+        desc = _get_first_line(m.get("description", ""))
+        status = ""
+        if name in installed_names:
+            status = tr_multi("\u2713 instalita", "\u2713 installed", "\u2713 install\u00e9")
+        table.add_row(str(i), display, desc, status)
+
+    console.print(table)
+
+
+@modulo_app.command("serci")
+def modulo_serci(
+    keyword: str = typer.Argument(
+        ...,
+        help=tr_multi(
+            "\u015closilvorto por ser\u0109i modulojn",
+            "Keyword to search modules",
+            "Mot-cl\u00e9 pour rechercher des modules",
+        ),
+    ),
+    refresh: bool = typer.Option(
+        False,
+        "--refresh",
+        help=tr_multi(
+            "Refre\u015digi la manifeston de la reto",
+            "Refresh the registry from network",
+            "Actualiser le registre depuis le r\u00e9seau",
+        ),
+    ),
+) -> None:
+    """Ser\u0109i modulojn la\u016d nomo a\u016d priskribo."""
+    # Force refresh before searching
+    if refresh:
+        fetch_registry(refresh=True)
+
+    results = search_registry(keyword)
+
+    if not results:
+        info(tr_multi(
+            f"Neniuj rezultoj por '{keyword}'.",
+            f"No results for '{keyword}'.",
+            f"Aucun r\u00e9sultat pour '{keyword}'.",
+        ))
+        return
+
+    if len(results) == 1:
+        _show_module_info(results[0])
+        return
+
+    # Multiple results — use interactive selection
+    result = select_candidate(
+        results,
+        columns=[
+            {
+                "header": tr_multi("Nomo", "Name", "Nom"),
+                "style": "bold",
+            },
+            {
+                "header": tr_multi("Priskribo", "Description", "Description"),
+                "style": "dim",
+            },
+        ],
+        row_formatter=lambda m, i: [
+            m.get("display_name", m.get("name", "")),
+            _get_first_line(m.get("description", ""), 50),
+        ],
+    )
+    if result is not None:
+        _show_module_info(result[1])
+
+
+def _show_module_info(module: dict) -> None:
+    """Display a single module's information panel."""
+    name = module.get("display_name", module.get("name", ""))
+    pip = module.get("pip", "")
+    desc = module.get("description", "")
+
+    # Check install status
+    installed_names = {m["name"] for m in get_installed_modules()}
+    is_installed = module.get("name", "") in installed_names
+
+    status_text = (
+        tr_multi("\u2713 instalita", "\u2713 installed", "\u2713 install\u00e9")
+        if is_installed
+        else tr_multi("havebla", "available", "disponible")
+    )
+
+    # Render description as HTML for panel body
+    body = render_markdown(desc)
+
+    panel = Panel(
+        body,
+        title=f"[bold]{name}[/bold]",
+        subtitle=f"[dim]pip install {pip}[/dim]",
+    )
+    console.print(panel)
+    console.print(f"[dim]Stato: {status_text}[/dim]")
+    console.print(panel)
+
+
+@modulo_app.command("info")
+def modulo_info(
+    name: str = typer.Argument(
+        ...,
+        help=tr_multi(
+            "Nomo de la moduloj",
+            "Module name",
+            "Nom du module",
+        ),
+    ),
+    refresh: bool = typer.Option(
+        False,
+        "--refresh",
+        help=tr_multi(
+            "Refre\u015digi la manifeston de la reto",
+            "Refresh the registry from network",
+            "Actualiser le registre depuis le r\u00e9seau",
+        ),
+    ),
+) -> None:
+    """Vidi detalajn informojn pri modulo."""
+    if refresh:
+        fetch_registry(refresh=True)
+
+    module = get_module_info(name)
+    if module is None:
+        error(tr_multi(
+            f"Modulo '{name}' ne trovita en la registraro.",
+            f"Module '{name}' not found in the registry.",
+            f"Module '{name}' introuvable dans le registre.",
+        ))
+        # Show available names
+        data = fetch_registry()
+        if data:
+            names = ", ".join(m.get("name", "") for m in data.get("modules", []))
+            info(tr_multi(
+                f"Disponeblaj moduloj: {names}",
+                f"Available modules: {names}",
+                f"Modules disponibles : {names}",
+            ))
+        raise typer.Exit(1)
+
+    _show_module_info(module)
+
+
+app.add_typer(modulo_app, name="modulo")
 
 
 def main():

--- a/src/A/core/exceptions.py
+++ b/src/A/core/exceptions.py
@@ -30,3 +30,8 @@ class DataError(AError):
 class CommandError(AError):
     """Command execution errors."""
     pass
+
+
+class RegistryError(AError):
+    """Module registry fetch/parse errors."""
+    pass

--- a/src/A/core/registry.py
+++ b/src/A/core/registry.py
@@ -1,0 +1,238 @@
+"""Module registry — fetch, cache, and search the A-module manifest.
+
+Provides:
+- ``fetch_registry()`` — download and cache ``modules.json`` from GitHub
+- ``search_registry()`` — case-insensitive search by name/description
+- ``get_module_info()`` — fetch a single module entry
+- ``get_installed_modules()`` — discover already-installed A-modules
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from A.core.exceptions import RegistryError
+from A.core.paths import cache_dir, ensure_dirs
+from A.core.config import get_setting
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+DEFAULT_REGISTRY_URL = (
+    "https://raw.githubusercontent.com/Ron-RONZZ-org/A-core/main/modules.json"
+)
+ENV_REGISTRY_URL = "A_MODULE_REGISTRY_URL"
+CONFIG_REGISTRY_KEY = "module_registry_url"
+DEFAULT_CACHE_TTL_SECONDS = 86400  # 24 hours
+
+# ── URL resolution ───────────────────────────────────────────────────────────
+
+
+def _get_registry_url() -> str:
+    """Resolve the registry URL: env var > config > default."""
+    env_url = os.environ.get(ENV_REGISTRY_URL)
+    if env_url:
+        return env_url
+    config_url: str | None = get_setting(CONFIG_REGISTRY_KEY)
+    if config_url:
+        return config_url
+    return DEFAULT_REGISTRY_URL
+
+
+def _get_cache_path() -> Path:
+    """Return the path to the cached manifest file."""
+    ensure_dirs()
+    return cache_dir() / "modules.json"
+
+
+def _get_cache_ttl() -> int:
+    """Return the cache TTL in seconds (configurable)."""
+    return int(get_setting("module_cache_ttl", DEFAULT_CACHE_TTL_SECONDS))
+
+
+# ── Cache invalidation ───────────────────────────────────────────────────────
+
+
+def _is_cache_valid(cache_path: Path) -> bool:
+    """Check whether the local cache is still fresh."""
+    if not cache_path.exists():
+        return False
+    ttl = _get_cache_ttl()
+    age = time.time() - cache_path.stat().st_mtime
+    return age < ttl
+
+
+# ── HTTP fetching ────────────────────────────────────────────────────────────
+
+
+def _fetch_url(url: str) -> str:
+    """Download *url* and return its text content.
+
+    Raises ``RegistryError`` on network or HTTP errors.
+    """
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            if resp.status != 200:
+                raise RegistryError(
+                    f"HTTP {resp.status} fetching registry from {url}"
+                )
+            return resp.read().decode("utf-8")
+    except urllib.error.URLError as exc:
+        raise RegistryError(f"Network error fetching registry: {exc}") from exc
+    except OSError as exc:
+        raise RegistryError(f"Connection error: {exc}") from exc
+
+
+# ── Validate manifest structure ──────────────────────────────────────────────
+
+
+def _validate_manifest(data: Any) -> dict:
+    """Validate that *data* is a dict with the required manifest keys.
+
+    Returns the validated dict or raises ``RegistryError``.
+    """
+    if not isinstance(data, dict):
+        raise RegistryError("Registry manifest must be a JSON object")
+    if "version" not in data:
+        raise RegistryError("Registry manifest missing required field: 'version'")
+    if "modules" not in data:
+        raise RegistryError("Registry manifest missing required field: 'modules'")
+    if not isinstance(data["modules"], list):
+        raise RegistryError("Registry manifest 'modules' must be an array")
+    return data
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+
+def fetch_registry(*, refresh: bool = False) -> dict | None:
+    """Fetch the module registry, using cache when possible.
+
+    Parameters
+    ----------
+    refresh:
+        If True, skip the cache and always fetch from the network.
+
+    Returns
+    -------
+    The parsed manifest dict (``{"version": …, "modules": […]}``) or
+    ``None`` if the registry is unreachable and no cache exists.
+    """
+    cache_path = _get_cache_path()
+    url = _get_registry_url()
+
+    # 1. Try cache first (unless refresh requested)
+    if not refresh and _is_cache_valid(cache_path):
+        try:
+            raw = cache_path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+            return _validate_manifest(data)
+        except (OSError, json.JSONDecodeError, RegistryError) as exc:
+            # Corrupt cache — delete and fall through to re-fetch
+            cache_path.unlink(missing_ok=True)
+
+    # 2. Fetch from network
+    try:
+        raw = _fetch_url(url)
+        data = json.loads(raw)
+        data = _validate_manifest(data)
+        # Write to cache
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(raw, encoding="utf-8")
+        return data
+    except (RegistryError, OSError, json.JSONDecodeError) as exc:
+        # 3. Network failed — try stale cache as fallback
+        if cache_path.exists():
+            from A import warning
+            warning(
+                f"Ne eblas atingi la modul-registron. "
+                f"Uzas ka\x0159itan daton (eble malaktuala).\n"
+                f"Detalo: {exc}"
+            )
+            try:
+                raw = cache_path.read_text(encoding="utf-8")
+                return _validate_manifest(json.loads(raw))
+            except (OSError, json.JSONDecodeError, RegistryError):
+                cache_path.unlink(missing_ok=True)
+                return None
+        return None
+
+
+def search_registry(query: str) -> list[dict]:
+    """Search the registry by module *name* or *description*.
+
+    Performs a case-insensitive substring match. Returns matching entries
+    sorted alphabetically by ``name``.
+    """
+    data = fetch_registry()
+    if data is None:
+        return []
+    q = query.lower().strip()
+    if not q:
+        return sorted(data["modules"], key=lambda m: m.get("name", ""))
+
+    matches = [
+        m
+        for m in data["modules"]
+        if q in m.get("name", "").lower()
+        or q in m.get("description", "").lower()
+        or q in m.get("display_name", "").lower()
+    ]
+    return sorted(matches, key=lambda m: m.get("name", ""))
+
+
+def get_module_info(name: str) -> dict | None:
+    """Return the manifest entry for a single module by *name*.
+
+    Matching is case-insensitive.
+    """
+    data = fetch_registry()
+    if data is None:
+        return None
+    q = name.lower().strip()
+    for m in data["modules"]:
+        if m.get("name", "").lower() == q:
+            return m
+    return None
+
+
+def get_installed_modules() -> list[dict]:
+    """Discover installed A-modules via entry points and cross-reference
+    with the manifest.
+
+    Returns a list of dicts each with at least ``name`` and ``display_name``.
+    If the module is found in the manifest the full entry is returned.
+    """
+    import importlib.metadata
+
+    installed: list[dict] = []
+    try:
+        eps = importlib.metadata.entry_points(group="A.commands")
+    except TypeError:
+        eps = importlib.metadata.entry_points().get("A.commands", [])
+
+    # Build a lookup from name → manifest entry (cached)
+    manifest = fetch_registry()
+    manifest_lookup: dict[str, dict] = {}
+    if manifest:
+        for m in manifest["modules"]:
+            manifest_lookup[m["name"]] = m
+
+    for ep in eps:
+        name = ep.name
+        if name in manifest_lookup:
+            installed.append(dict(manifest_lookup[name]))
+        else:
+            installed.append({
+                "name": name,
+                "display_name": name.capitalize(),
+                "pip": f"A-{name}",
+                "description": "",
+            })
+
+    return sorted(installed, key=lambda m: m.get("name", ""))

--- a/src/A/utils/interactive.py
+++ b/src/A/utils/interactive.py
@@ -1,0 +1,110 @@
+"""
+Generic interactive selection utilities for A CLI.
+
+Provides a reusable "show numbered table → prompt for selection" pattern
+that can be used across all A-modules.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, TypeVar
+
+import typer
+from rich.table import Table
+
+from A import tr_multi
+from A.utils.output import info, console
+
+T = TypeVar("T")
+
+
+def select_candidate(
+    candidates: list[T],
+    *,
+    columns: list[dict[str, Any]],
+    row_formatter: Callable[[T, int], list[str]],
+    prompt_text: str | None = None,
+    default: str = "",
+) -> tuple[int, T] | None:
+    """Display a numbered table of *candidates* and prompt the user to
+    select one.
+
+    Parameters
+    ----------
+    candidates:
+        The items to present for selection.
+    columns:
+        Rich ``Table`` column definitions **without** the auto ``#`` column.
+        Each entry: ``{"header": str, "style": str | None, "width": int | None}``.
+    row_formatter:
+        ``Callable[[item, 1-based-index], list[str]]`` that returns the cell
+        values for a single row.
+    prompt_text:
+        Prompt shown to the user.  Defaults to a tr()-translated message.
+    default:
+        Default input when the user presses Enter (``""`` = skip).
+
+    Returns
+    -------
+    A ``(0-based-index, item)`` tuple or ``None`` if the user skipped.
+    """
+    if not candidates:
+        return None
+
+    # Build table
+    table = Table(show_header=True, header_style="dim", box=None)
+    table.add_column("#", style="dim", width=3)
+    for col in columns:
+        table.add_column(
+            col.get("header", ""),
+            style=col.get("style"),
+            width=col.get("width"),
+        )
+
+    for i, item in enumerate(candidates, 1):
+        cells = row_formatter(item, i)
+        table.add_row(str(i), *cells)
+
+    console.print(table)
+
+    n = len(candidates)
+    info(tr_multi(f"{n} rezultoj", f"{n} results", f"{n} r\u00e9sultats"))
+
+    text = prompt_text or tr_multi(
+        "Elektu numeron por vidi detalojn (a\u016d Enter por preteriri)",
+        "Select a number to view details (or Enter to skip)",
+        "Choisissez un num\u00e9ro (ou Entr\u00e9e pour ignorer)",
+    )
+    raw = typer.prompt(text, default=default)
+    if not raw.strip():
+        return None
+
+    try:
+        idx = int(raw.strip()) - 1
+    except ValueError:
+        return None
+
+    if 0 <= idx < len(candidates):
+        return (idx, candidates[idx])
+    return None
+
+
+def confirm_action(
+    message: str,
+    *,
+    default: bool = False,
+) -> bool:
+    """Display a yes/no confirmation prompt.
+
+    Parameters
+    ----------
+    message:
+        The question to show.
+    default:
+        Default answer (used when user presses Enter).
+
+    Returns
+    -------
+    ``True`` if confirmed, ``False`` otherwise.
+    """
+    return typer.confirm(message, default=default)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,154 @@
+"""CLI tests for A-core."""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+from typer.testing import CliRunner
+
+from A.cli import app
+
+runner = CliRunner()
+
+
+# ── A list (deprecated) ──────────────────────────────────────────────────────
+
+
+@patch("A.cli.modulo_ls")
+def test_list_deprecation(mock_modulo_ls):
+    """Old A list shows deprecation warning and delegates."""
+    result = runner.invoke(app, ["list"])
+    assert result.exit_code == 0
+    assert "malrekomendita" in result.stdout or "deprecated" in result.stdout
+    mock_modulo_ls.assert_called_once_with(instalita=True)
+
+
+# ── A modulo ls ──────────────────────────────────────────────────────────────
+
+
+@patch("A.cli.fetch_registry")
+@patch("A.cli.get_installed_modules")
+def test_modulo_ls_installed(mock_installed, mock_fetch):
+    """A modulo ls --instalita shows installed modules."""
+    mock_installed.return_value = [
+        {"name": "tempo", "display_name": "Tempo", "pip": "A-tempo"},
+    ]
+
+    result = runner.invoke(app, ["modulo", "ls", "--instalita"])
+    assert result.exit_code == 0
+    assert "Tempo" in result.stdout
+    assert "A-tempo" in result.stdout
+
+
+@patch("A.cli.fetch_registry")
+@patch("A.cli.get_installed_modules")
+def test_modulo_ls_installed_empty(mock_installed, mock_fetch):
+    """A modulo ls --instalita with no modules shows message."""
+    mock_installed.return_value = []
+
+    result = runner.invoke(app, ["modulo", "ls", "--instalita"])
+    assert result.exit_code == 0
+    assert "Neniuj" in result.stdout or "No modules" in result.stdout
+
+
+@patch("A.cli.fetch_registry")
+@patch("A.cli.get_installed_modules")
+def test_modulo_ls_all(mock_installed, mock_fetch):
+    """A modulo ls shows all modules with status."""
+    mock_fetch.return_value = {
+        "version": 1,
+        "modules": [
+            {"name": "tempo", "display_name": "Tempo", "description": "# T\n\nClock."},
+            {"name": "vorto", "display_name": "Vorto", "description": "# V\n\nWords."},
+        ],
+    }
+    mock_installed.return_value = [{"name": "tempo"}]
+
+    result = runner.invoke(app, ["modulo", "ls"])
+    assert result.exit_code == 0
+    assert "Tempo" in result.stdout
+    assert "Vorto" in result.stdout
+    assert "\u2713" in result.stdout  # checkmark for installed
+
+
+@patch("A.cli.fetch_registry")
+def test_modulo_ls_no_manifest(mock_fetch):
+    """A modulo ls with no registry shows error."""
+    mock_fetch.return_value = None
+
+    result = runner.invoke(app, ["modulo", "ls"])
+    assert result.exit_code != 0
+
+
+# ── A modulo serci ───────────────────────────────────────────────────────────
+
+
+@patch("A.cli.search_registry")
+@patch("A.cli.fetch_registry")
+def test_modulo_serci_no_results(mock_fetch, mock_search):
+    """A modulo serci with no matches shows message."""
+    mock_search.return_value = []
+
+    result = runner.invoke(app, ["modulo", "serci", "xyzzy"])
+    assert result.exit_code == 0
+    assert "Neniuj" in result.stdout or "No results" in result.stdout
+
+
+@patch("A.cli._show_module_info")
+@patch("A.cli.search_registry")
+@patch("A.cli.fetch_registry")
+def test_modulo_serci_one_result(mock_fetch, mock_search, mock_show):
+    """Single search result shows info directly."""
+    mock_search.return_value = [{"name": "tempo", "display_name": "Tempo"}]
+
+    result = runner.invoke(app, ["modulo", "serci", "tempo"])
+    assert result.exit_code == 0
+    mock_show.assert_called_once()
+
+
+@patch("A.cli.select_candidate")
+@patch("A.cli.search_registry")
+@patch("A.cli.fetch_registry")
+def test_modulo_serci_multi_select(mock_fetch, mock_search, mock_select):
+    """Multiple search results use interactive selection."""
+    mock_search.return_value = [
+        {"name": "tempo", "display_name": "Tempo"},
+        {"name": "vorto", "display_name": "Vorto"},
+    ]
+    mock_select.return_value = (0, mock_search.return_value[0])
+
+    result = runner.invoke(app, ["modulo", "serci", "o"])
+    assert result.exit_code == 0
+
+
+# ── A modulo info ────────────────────────────────────────────────────────────
+
+
+@patch("A.cli.get_module_info")
+@patch("A.cli.get_installed_modules")
+def test_modulo_info_found(mock_installed, mock_info):
+    """A modulo info shows module panel."""
+    mock_installed.return_value = [{"name": "tempo"}]
+    mock_info.return_value = {
+        "name": "tempo",
+        "display_name": "Tempo",
+        "pip": "A-tempo",
+        "description": "# Tempo\n\nClock.",
+    }
+
+    result = runner.invoke(app, ["modulo", "info", "tempo"])
+    assert result.exit_code == 0
+    assert "Tempo" in result.stdout
+    assert "A-tempo" in result.stdout
+
+
+@patch("A.cli.get_module_info")
+@patch("A.cli.fetch_registry")
+def test_modulo_info_not_found(mock_fetch, mock_info):
+    """A modulo info on unknown module shows error."""
+    mock_info.return_value = None
+    mock_fetch.return_value = {"version": 1, "modules": []}
+
+    result = runner.invoke(app, ["modulo", "info", "nonexistent"])
+    assert result.exit_code != 0
+    assert "ne trovita" in result.stdout or "not found" in result.stdout

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,0 +1,153 @@
+"""Tests for A.utils.interactive."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from A.utils.interactive import select_candidate, confirm_action
+
+
+# ── select_candidate ─────────────────────────────────────────────────────────
+
+
+def _simple_formatter(item: str, idx: int) -> list[str]:
+    return [item, str(len(item))]
+
+
+COLUMNS = [
+    {"header": "Item", "style": "bold"},
+    {"header": "Length", "style": "dim", "width": 6},
+]
+
+
+@patch("A.utils.interactive.typer.prompt")
+def test_select_valid(mock_prompt):
+    """Valid selection returns correct (index, item)."""
+    candidates = ["apple", "banana", "cherry"]
+    mock_prompt.return_value = "2"
+
+    result = select_candidate(candidates, columns=COLUMNS, row_formatter=_simple_formatter)
+    assert result is not None
+    idx, item = result
+    assert idx == 1
+    assert item == "banana"
+
+
+@patch("A.utils.interactive.typer.prompt")
+def test_select_skip(mock_prompt):
+    """Empty input (Enter) returns None."""
+    candidates = ["apple", "banana"]
+    mock_prompt.return_value = ""
+
+    result = select_candidate(candidates, columns=COLUMNS, row_formatter=_simple_formatter)
+    assert result is None
+
+
+@patch("A.utils.interactive.typer.prompt")
+def test_select_invalid_input(mock_prompt):
+    """Non-numeric input returns None."""
+    candidates = ["apple", "banana"]
+    mock_prompt.return_value = "abc"
+
+    result = select_candidate(candidates, columns=COLUMNS, row_formatter=_simple_formatter)
+    assert result is None
+
+
+@patch("A.utils.interactive.typer.prompt")
+def test_select_out_of_range(mock_prompt):
+    """Out-of-range index returns None."""
+    candidates = ["apple", "banana"]
+    mock_prompt.return_value = "999"
+
+    result = select_candidate(candidates, columns=COLUMNS, row_formatter=_simple_formatter)
+    assert result is None
+
+
+@patch("A.utils.interactive.typer.prompt")
+def test_select_zero_index(mock_prompt):
+    """0 (before 1-based range) returns None."""
+    candidates = ["apple", "banana"]
+    mock_prompt.return_value = "0"
+
+    result = select_candidate(candidates, columns=COLUMNS, row_formatter=_simple_formatter)
+    assert result is None
+
+
+@patch("A.utils.interactive.typer.prompt")
+def test_select_last_item(mock_prompt):
+    """Last index is valid."""
+    candidates = ["apple", "banana", "cherry"]
+    mock_prompt.return_value = "3"
+
+    result = select_candidate(candidates, columns=COLUMNS, row_formatter=_simple_formatter)
+    assert result is not None
+    idx, item = result
+    assert idx == 2
+    assert item == "cherry"
+
+
+def test_select_empty_list():
+    """Empty candidates returns None without prompting."""
+    result = select_candidate([], columns=COLUMNS, row_formatter=_simple_formatter)
+    assert result is None
+
+
+@patch("A.utils.interactive.typer.prompt")
+def test_select_custom_prompt(mock_prompt):
+    """Custom prompt text is used."""
+    candidates = ["apple"]
+    mock_prompt.return_value = "1"
+
+    result = select_candidate(
+        candidates,
+        columns=COLUMNS,
+        row_formatter=_simple_formatter,
+        prompt_text="Pick one:",
+        default="1",
+    )
+    assert result is not None
+    mock_prompt.assert_called_with("Pick one:", default="1")
+
+
+@patch("A.utils.interactive.typer.prompt")
+def test_select_row_formatter_called(mock_prompt):
+    """Row formatter is called for each candidate."""
+    candidates = ["a", "b"]
+    calls = []
+
+    def spy_formatter(item: str, idx: int) -> list[str]:
+        calls.append((item, idx))
+        return [item]
+
+    mock_prompt.return_value = "1"
+    select_candidate(candidates, columns=[{"header": "X"}], row_formatter=spy_formatter)
+
+    assert calls == [("a", 1), ("b", 2)]
+
+
+# ── confirm_action ───────────────────────────────────────────────────────────
+
+
+@patch("A.utils.interactive.typer.confirm")
+def test_confirm_yes(mock_confirm):
+    """confirm_action returns True when confirmed."""
+    mock_confirm.return_value = True
+    assert confirm_action("Proceed?") is True
+    mock_confirm.assert_called_with("Proceed?", default=False)
+
+
+@patch("A.utils.interactive.typer.confirm")
+def test_confirm_no(mock_confirm):
+    """confirm_action returns False when declined."""
+    mock_confirm.return_value = False
+    assert confirm_action("Proceed?") is False
+
+
+@patch("A.utils.interactive.typer.confirm")
+def test_confirm_default(mock_confirm):
+    """Default value is passed to typer.confirm."""
+    mock_confirm.return_value = True
+    confirm_action("Proceed?", default=True)
+    mock_confirm.assert_called_with("Proceed?", default=True)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,360 @@
+"""Tests for A.core.registry."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from A.core.registry import (
+    DEFAULT_REGISTRY_URL,
+    ENV_REGISTRY_URL,
+    _get_registry_url,
+    _is_cache_valid,
+    _validate_manifest,
+    fetch_registry,
+    get_installed_modules,
+    get_module_info,
+    search_registry,
+)
+from A.core.exceptions import RegistryError
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def valid_manifest() -> dict:
+    return {
+        "version": 1,
+        "schema_version": "1.0",
+        "updated": "2026-05-03T00:00:00Z",
+        "modules": [
+            {
+                "name": "tempo",
+                "display_name": "Tempo",
+                "pip": "A-tempo",
+                "description": "# Tempo\n\nClock plugin.\n\n## Installation\n\n```\npip install A-tempo\n```\n",
+            },
+            {
+                "name": "vorto",
+                "display_name": "Vorto",
+                "pip": "A-vorto",
+                "description": "# Vorto\n\nWordbook plugin.\n\n## Installation\n\n```\npip install A-vorto\n```\n",
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def cache_dir(tmp_path: Path) -> Path:
+    cache = tmp_path / ".cache" / "A"
+    cache.mkdir(parents=True, exist_ok=True)
+    return cache
+
+
+# ── _get_registry_url ────────────────────────────────────────────────────────
+
+
+def test_registry_url_default():
+    """Default URL is the GitHub raw URL."""
+    url = _get_registry_url()
+    assert url == DEFAULT_REGISTRY_URL
+
+
+def test_registry_url_from_env(monkeypatch):
+    """Env var overrides default."""
+    monkeypatch.setenv(ENV_REGISTRY_URL, "https://example.com/modules.json")
+    assert _get_registry_url() == "https://example.com/modules.json"
+
+
+def test_registry_url_from_config(monkeypatch):
+    """Config value overrides default (but env still wins)."""
+    monkeypatch.delenv(ENV_REGISTRY_URL, raising=False)
+    with patch("A.core.registry.get_setting") as mock_get:
+        mock_get.return_value = "https://config.example.com/modules.json"
+        assert _get_registry_url() == "https://config.example.com/modules.json"
+
+
+# ── _is_cache_valid ──────────────────────────────────────────────────────────
+
+
+def test_cache_valid(cache_dir):
+    """Cache file within TTL is valid."""
+    cache_path = cache_dir / "modules.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    assert _is_cache_valid(cache_path)
+
+
+def test_cache_expired(cache_dir):
+    """Cache file older than TTL is invalid."""
+    cache_path = cache_dir / "modules.json"
+    cache_path.write_text("{}", encoding="utf-8")
+    # Set mtime far in the past
+    old_time = time.time() - 999999
+    os.utime(cache_path, (old_time, old_time))
+    assert not _is_cache_valid(cache_path)
+
+
+def test_cache_missing(cache_dir):
+    """Non-existent cache is invalid."""
+    cache_path = cache_dir / "modules.json"
+    assert not _is_cache_valid(cache_path)
+
+
+# ── _validate_manifest ───────────────────────────────────────────────────────
+
+
+def test_validate_valid(valid_manifest):
+    """Valid manifest passes validation."""
+    result = _validate_manifest(valid_manifest)
+    assert result == valid_manifest
+
+
+def test_validate_not_dict():
+    """Non-dict raises RegistryError."""
+    with pytest.raises(RegistryError):
+        _validate_manifest([])
+
+
+def test_validate_missing_version(valid_manifest):
+    """Missing version key raises RegistryError."""
+    del valid_manifest["version"]
+    with pytest.raises(RegistryError):
+        _validate_manifest(valid_manifest)
+
+
+def test_validate_missing_modules(valid_manifest):
+    """Missing modules key raises RegistryError."""
+    del valid_manifest["modules"]
+    with pytest.raises(RegistryError):
+        _validate_manifest(valid_manifest)
+
+
+def test_validate_modules_not_list(valid_manifest):
+    """Non-list modules raises RegistryError."""
+    valid_manifest["modules"] = {}
+    with pytest.raises(RegistryError):
+        _validate_manifest(valid_manifest)
+
+
+# ── fetch_registry ───────────────────────────────────────────────────────────
+
+
+@patch("A.core.registry._get_cache_path")
+@patch("A.core.registry._fetch_url")
+def test_fetch_registry_success(
+    mock_fetch, mock_cache_path, cache_dir, valid_manifest
+):
+    """Successful HTTP fetch returns valid manifest and writes cache."""
+    mock_cache_path.return_value = cache_dir / "modules.json"
+    mock_fetch.return_value = json.dumps(valid_manifest)
+
+    result = fetch_registry(refresh=True)
+    assert result == valid_manifest
+    assert (cache_dir / "modules.json").exists()
+
+
+@patch("A.core.registry._get_cache_path")
+@patch("A.core.registry._fetch_url")
+def test_fetch_registry_offline_with_cache(
+    mock_fetch, mock_cache_path, cache_dir, valid_manifest
+):
+    """Offline fallback uses stale cache."""
+    cache_path = cache_dir / "modules.json"
+    cache_path.write_text(json.dumps(valid_manifest), encoding="utf-8")
+    mock_cache_path.return_value = cache_path
+    mock_fetch.side_effect = RegistryError("Network error")
+
+    result = fetch_registry(refresh=True)
+    assert result == valid_manifest
+
+
+@patch("A.core.registry._get_cache_path")
+@patch("A.core.registry._fetch_url")
+def test_fetch_registry_offline_no_cache(
+    mock_fetch, mock_cache_path, cache_dir
+):
+    """Offline with no cache returns None."""
+    mock_cache_path.return_value = cache_dir / "modules.json"
+    mock_fetch.side_effect = RegistryError("Network error")
+
+    result = fetch_registry(refresh=True)
+    assert result is None
+
+
+@patch("A.core.registry._get_cache_path")
+@patch("A.core.registry._fetch_url")
+def test_fetch_registry_corrupt_cache(
+    mock_fetch, mock_cache_path, cache_dir
+):
+    """Corrupt cache with no network returns None."""
+    cache_path = cache_dir / "modules.json"
+    cache_path.write_text("not json", encoding="utf-8")
+    mock_cache_path.return_value = cache_path
+    mock_fetch.side_effect = RegistryError("Network error")
+
+    result = fetch_registry(refresh=True)
+    assert result is None
+    # Corrupt cache should be deleted
+    assert not cache_path.exists()
+
+
+@patch("A.core.registry._get_cache_path")
+def test_fetch_registry_uses_cache(
+    mock_cache_path, cache_dir, valid_manifest
+):
+    """When cache is valid, no HTTP call is made."""
+    cache_path = cache_dir / "modules.json"
+    cache_path.write_text(json.dumps(valid_manifest), encoding="utf-8")
+    mock_cache_path.return_value = cache_path
+
+    with patch("A.core.registry._fetch_url") as mock_fetch:
+        result = fetch_registry()
+        assert result == valid_manifest
+        mock_fetch.assert_not_called()
+
+
+# ── search_registry ──────────────────────────────────────────────────────────
+
+
+@patch("A.core.registry.fetch_registry")
+def test_search_by_name(mock_fetch, valid_manifest):
+    """Search by name returns matching module."""
+    mock_fetch.return_value = valid_manifest
+    results = search_registry("tempo")
+    assert len(results) == 1
+    assert results[0]["name"] == "tempo"
+
+
+@patch("A.core.registry.fetch_registry")
+def test_search_by_description(mock_fetch, valid_manifest):
+    """Search by description returns matching module."""
+    mock_fetch.return_value = valid_manifest
+    results = search_registry("wordbook")
+    assert len(results) == 1
+    assert results[0]["name"] == "vorto"
+
+
+@patch("A.core.registry.fetch_registry")
+def test_search_case_insensitive(mock_fetch, valid_manifest):
+    """Search is case-insensitive."""
+    mock_fetch.return_value = valid_manifest
+    results = search_registry("TEMPO")
+    assert len(results) == 1
+    assert results[0]["name"] == "tempo"
+
+
+@patch("A.core.registry.fetch_registry")
+def test_search_no_match(mock_fetch, valid_manifest):
+    """No match returns empty list."""
+    mock_fetch.return_value = valid_manifest
+    results = search_registry("nonexistent")
+    assert results == []
+
+
+@patch("A.core.registry.fetch_registry")
+def test_search_empty_query(mock_fetch, valid_manifest):
+    """Empty query returns all modules."""
+    mock_fetch.return_value = valid_manifest
+    results = search_registry("")
+    assert len(results) == 2
+
+
+@patch("A.core.registry.fetch_registry")
+def test_search_registry_unavailable(mock_fetch):
+    """Registry unavailable returns empty list."""
+    mock_fetch.return_value = None
+    results = search_registry("tempo")
+    assert results == []
+
+
+# ── get_module_info ──────────────────────────────────────────────────────────
+
+
+@patch("A.core.registry.fetch_registry")
+def test_get_module_info_found(mock_fetch, valid_manifest):
+    """Existing module returns its info dict."""
+    mock_fetch.return_value = valid_manifest
+    info = get_module_info("tempo")
+    assert info is not None
+    assert info["name"] == "tempo"
+
+
+@patch("A.core.registry.fetch_registry")
+def test_get_module_info_not_found(mock_fetch, valid_manifest):
+    """Non-existing module returns None."""
+    mock_fetch.return_value = valid_manifest
+    info = get_module_info("nonexistent")
+    assert info is None
+
+
+@patch("A.core.registry.fetch_registry")
+def test_get_module_info_case_insensitive(mock_fetch, valid_manifest):
+    """Lookup is case-insensitive."""
+    mock_fetch.return_value = valid_manifest
+    info = get_module_info("TEMPO")
+    assert info is not None
+    assert info["name"] == "tempo"
+
+
+@patch("A.core.registry.fetch_registry")
+def test_get_module_info_unavailable(mock_fetch):
+    """Registry unavailable returns None."""
+    mock_fetch.return_value = None
+    info = get_module_info("tempo")
+    assert info is None
+
+
+# ── get_installed_modules ────────────────────────────────────────────────────
+
+
+@patch("A.core.registry.fetch_registry")
+@patch("importlib.metadata.entry_points")
+def test_get_installed_modules_some(
+    mock_ep, mock_fetch, valid_manifest
+):
+    """Installed modules are discovered via entry points."""
+    mock_fetch.return_value = valid_manifest
+
+    # Mock entry points
+    ep1 = MagicMock()
+    ep1.name = "tempo"
+    mock_ep.return_value = [ep1]
+
+    installed = get_installed_modules()
+    assert len(installed) == 1
+    assert installed[0]["name"] == "tempo"
+    assert installed[0]["display_name"] == "Tempo"
+
+
+@patch("A.core.registry.fetch_registry")
+@patch("importlib.metadata.entry_points")
+def test_get_installed_modules_none(mock_ep, mock_fetch, valid_manifest):
+    """No installed modules returns empty list."""
+    mock_fetch.return_value = valid_manifest
+    mock_ep.return_value = []
+
+    installed = get_installed_modules()
+    assert installed == []
+
+
+@patch("A.core.registry.fetch_registry")
+@patch("importlib.metadata.entry_points")
+def test_get_installed_modules_unknown(mock_ep, mock_fetch, valid_manifest):
+    """Unknown (not in manifest) modules still appear."""
+    mock_fetch.return_value = valid_manifest
+
+    ep1 = MagicMock()
+    ep1.name = "unknown-module"
+    mock_ep.return_value = [ep1]
+
+    installed = get_installed_modules()
+    assert len(installed) == 1
+    assert installed[0]["name"] == "unknown-module"
+    assert installed[0]["display_name"] == "Unknown-module"
+    assert installed[0]["pip"] == "A-unknown-module"


### PR DESCRIPTION
## Summary
- Add `A modulo` subcommand group to A-core for module discovery
- Create `modules.json` manifest with all 9 official A-modules
- Add `A.core.registry` module: fetch, cache, search module manifest
- Add `A.utils.interactive` module: generic numbered-table selection utility
- Deprecate `A list` in favor of `A modulo ls --instalita`
- Configurable registry URL (env var `A_MODULE_REGISTRY_URL` + config key)
- Configurable cache TTL (default 24h) with offline stale-cache fallback
- 51 tests across registry, interactive, and CLI test suites

## CLI Commands
```
A modulo ls              # list available modules (installed at bottom)
A modulo ls --instalita  # list only installed (replaces A list)
A modulo serci <kw>     # search with interactive multi-select
A modulo info <name>    # detailed module info panel
```

## Migration
- A-encik updated to use `A.utils.interactive.select_candidate` instead of inline prompt loops
- Old `A list` kept with deprecation warning, delegates to `A modulo ls --instalita`