### PR TITLE
fix: global i18n issues - locale-aware confirm_action and tr() fallback chain (#50)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,21 @@ src/A/
 | Dynamic/runtime strings | `tr_multi(eo, en, fr)` inline |
 | Docstrings (internal) | English (not user-facing) |
 
+### i18n Fallback Rules
+
+- **`tr()` fallback chain:** `current_language → eo (Esperanto) → en (English) → key`
+- **`tr_multi()` fallback chain:** `eo → en → fr` (each parameter falls back to the previous)
+- **`confirm_action()` prompt suffix** adapts to the current language:
+  - `eo`: `[j/n]` (jes/ne)
+  - `en`: `[y/n]` (yes/no)
+  - `fr`: `[o/n]` (oui/non)
+
+### i18n Rules
+
+1. All user-facing strings in `error()`, `info()`, `success()`, `warning()` MUST use `tr()` or `tr_multi()`
+2. Never hardcode Esperanto strings directly in CLI output — always wrap in `tr_multi()` for consistency
+3. Always provide Esperanto as first argument, English second, French third
+
 ---
 
 ## Code Standards

--- a/src/A/cli.py
+++ b/src/A/cli.py
@@ -13,7 +13,7 @@ from A.core.migration import get_status, migrate_all, MigrationStatus
 from A.core.registry import fetch_registry, get_module_info, get_installed_modules, search_registry
 from A.core.markdown_parser import render_markdown
 from A.utils import info, success, error, warning, console
-from A.utils.interactive import select_candidate
+from A.utils.interactive import select_candidate, confirm_action
 
 
 # ── Lazy Plugin Loading ──────────────────────────────────────────────────────
@@ -44,11 +44,19 @@ def _load_plugin(name: str) -> typer.main.TyperGroup | None:
     try:
         real = ep.load()
         if not isinstance(real, typer.Typer):
-            error(f"invalid plugin {name}: not a Typer app")
+            error(tr_multi(
+                f"Nevalida kromprogramo '{name}': ne estas Typer-apliko",
+                f"Invalid plugin '{name}': not a Typer app",
+                f"Plugin '{name}' invalide: n'est pas une application Typer",
+            ))
             return None
         return typer.main.get_command(real)
     except Exception as e:
-        error(f"failed to load {name}: {e}")
+        error(tr_multi(
+            f"Malsukcesis sxargi '{name}': {e}",
+            f"Failed to load '{name}': {e}",
+            f"Echec du chargement de '{name}': {e}",
+        ))
         return None
 
 
@@ -185,10 +193,18 @@ def migri_callback(ctx: typer.Context) -> None:
     results = migrate_all()
 
     if not results:
-        info("Neniuj migrationoj haveblas.")
+        info(tr_multi(
+            "Neniuj migradoj haveblas.",
+            "No migrations available.",
+            "Aucune migration disponible.",
+        ))
         return
 
-    success("Rezultoj de migrado:")
+    success(tr_multi(
+        "Rezultoj de migrado:",
+        "Migration results:",
+        "Résultats de la migration:",
+    ))
     for module, result in results.items():
         if result.skipped:
             info(f"  {module}: saltita ({result.skipped_reason})")
@@ -221,11 +237,23 @@ def show_migration_status() -> None:
     discovered = _discover_migrations()
 
     if not discovered:
-        info("Neniuj migr-moduloj trovite.")
-        info("Instalu A-modulojn kun migr-ad funkcioj.")
+        info(tr_multi(
+            "Neniuj migr-moduloj trovite.",
+            "No migration modules found.",
+            "Aucun module de migration trouvé.",
+        ))
+        info(tr_multi(
+            "Instalu A-modulojn kun migradaj funkcioj.",
+            "Install A-modules with migration features.",
+            "Installez des modules A avec fonctions de migration.",
+        ))
         return
 
-    success(f"Migrada stato ({len(discovered)} moduloj):")
+    success(tr_multi(
+        f"Migrada stato ({len(discovered)} moduloj):",
+        f"Migration status ({len(discovered)} modules):",
+        f"Statut de migration ({len(discovered)} modules):",
+    ))
 
     status_map = get_status()
 
@@ -281,10 +309,9 @@ def _ensure_keyring() -> bool:
         importlib.import_module("keyring")
         return True
     except ImportError:
-        import typer
         from A import tr_multi
-        
-        answer = typer.confirm(
+
+        answer = confirm_action(
             tr_multi(
                 "Bezonas 'keyring' bibliotekon. Ĉu instali ĝin nun?",
                 "The 'keyring' library is required. Install it now?",
@@ -294,33 +321,23 @@ def _ensure_keyring() -> bool:
         )
         if not answer:
             return False
-        
+
         try:
             import subprocess
             pip_cmd = _get_pip_command()
-            # Suppress pip output unless it fails
             subprocess.check_call(
                 pip_cmd + ["install", "keyring"],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
-            # Re-import after install
             importlib.import_module("keyring")
             return True
         except Exception as e:
-            error(f"Instalo malsukoresis: {e}")
-            return False
-        
-        try:
-            import subprocess, sys
-            subprocess.check_call(
-                [sys.executable, "-m", "pip", "install", "keyring"]
-            )
-            # Re-import after install
-            importlib.import_module("keyring")
-            return True
-        except Exception as e:
-            error(f"Instalo malsukcesis: {e}")
+            error(tr_multi(
+                f"Malsukcesis instali 'keyring': {e}",
+                f"Failed to install 'keyring': {e}",
+                f"Échec de l'installation de 'keyring': {e}",
+            ))
             return False
 
 

--- a/src/A/core/i18n.py
+++ b/src/A/core/i18n.py
@@ -312,19 +312,37 @@ def set_language(lang: str) -> None:
 
 
 def tr(key: str, lang: str = None) -> str:
-    """Translate a key. Falls back to English then key."""
+    """Translate a key.
+
+    Fallback chain: current_language -> eo (Esperanto) -> en (English) -> key.
+
+    Args:
+        key: Translation key (typically an Esperanto phrase)
+        lang: Optional language override (uses current language if None)
+
+    Returns:
+        Translated string
+    """
     if lang is None:
         lang = _current_lang
-    
+
     # Try current language first
-    if key in _translations.get(lang, {}):
-        return _translations[lang][key]
-    
+    translations = _translations.get(lang)
+    if translations and key in translations:
+        return translations[key]
+
+    # Fall back to Esperanto (primary authoring language)
+    if lang != "eo":
+        eo = _translations.get("eo")
+        if eo and key in eo:
+            return eo[key]
+
     # Fall back to English
-    if key in _translations.get("en", {}):
-        return _translations["en"][key]
-    
-    # Fall back to key itself
+    en = _translations.get("en")
+    if en and key in en:
+        return en[key]
+
+    # Return key itself (already Esperanto-like)
     return key
 
 
@@ -335,7 +353,6 @@ def tr_multi(eo: str, en: str = None, fr: str = None) -> str:
     Falls back: eo -> en -> eo.
     """
     translations = {"eo": eo, "en": en or eo, "fr": fr or en or eo}
-    current = _translations.get(_current_lang, {})
     return translations.get(_current_lang, eo)
 
 

--- a/src/A/utils/interactive.py
+++ b/src/A/utils/interactive.py
@@ -89,12 +89,26 @@ def select_candidate(
     return None
 
 
+_CONFIRM_PROMPTS: dict[str, tuple[str, str]] = {
+    "eo": ("j", "n"),  # jes / ne
+    "en": ("y", "n"),  # yes / no
+    "fr": ("o", "n"),  # oui / non
+}
+
+
 def confirm_action(
     message: str,
     *,
     default: bool = False,
+    yes_char: str | None = None,
+    no_char: str | None = None,
 ) -> bool:
-    """Display a yes/no confirmation prompt.
+    """Display a yes/no confirmation prompt with locale-aware characters.
+
+    The prompt suffix adapts to the current language:
+    - eo: ``[j/n]`` (jes/ne)
+    - en: ``[y/n]`` (yes/no)
+    - fr: ``[o/n]`` (oui/non)
 
     Parameters
     ----------
@@ -102,9 +116,29 @@ def confirm_action(
         The question to show.
     default:
         Default answer (used when user presses Enter).
+    yes_char:
+        Override the "yes" character (default: from current language).
+    no_char:
+        Override the "no" character (default: from current language).
 
     Returns
     -------
     ``True`` if confirmed, ``False`` otherwise.
     """
-    return typer.confirm(message, default=default)
+    from A.core.i18n import get_current_language
+
+    lang = get_current_language()
+    default_yes, default_no = _CONFIRM_PROMPTS.get(lang, ("y", "n"))
+    yes = (yes_char or default_yes).lower()
+    no = (no_char or default_no).lower()
+
+    prompt_suffix = f" [{yes}/{no}]"
+    default_str = yes if default else no
+
+    while True:
+        raw = typer.prompt(message + prompt_suffix, default=default_str)
+        raw = raw.strip().lower()
+        if raw == yes:
+            return True
+        if raw == no or not raw:
+            return default

--- a/src/A/utils/output.py
+++ b/src/A/utils/output.py
@@ -80,7 +80,12 @@ def print_table(
         )
     """
     if not rows:
-        info("Neniuj rezultoj.")
+        from A import tr_multi
+        info(tr_multi(
+            "Neniuj rezultoj.",
+            "No results.",
+            "Aucun résultat.",
+        ))
         return
 
     table = Table(title=title, show_header=True, header_style="bold")

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -130,24 +130,100 @@ def test_select_row_formatter_called(mock_prompt):
 # ── confirm_action ───────────────────────────────────────────────────────────
 
 
-@patch("A.utils.interactive.typer.confirm")
-def test_confirm_yes(mock_confirm):
-    """confirm_action returns True when confirmed."""
-    mock_confirm.return_value = True
+@patch("A.core.i18n.get_current_language")
+@patch("A.utils.interactive.typer.prompt")
+def test_confirm_yes_en(mock_prompt, mock_lang):
+    """English: entering 'y' returns True, prompt has [y/n]."""
+    mock_lang.return_value = "en"
+    mock_prompt.return_value = "y"
     assert confirm_action("Proceed?") is True
-    mock_confirm.assert_called_with("Proceed?", default=False)
+    mock_prompt.assert_called_once_with("Proceed? [y/n]", default="n")
 
 
-@patch("A.utils.interactive.typer.confirm")
-def test_confirm_no(mock_confirm):
-    """confirm_action returns False when declined."""
-    mock_confirm.return_value = False
+@patch("A.core.i18n.get_current_language")
+@patch("A.utils.interactive.typer.prompt")
+def test_confirm_no_en(mock_prompt, mock_lang):
+    """English: entering 'n' returns False."""
+    mock_lang.return_value = "en"
+    mock_prompt.return_value = "n"
     assert confirm_action("Proceed?") is False
 
 
-@patch("A.utils.interactive.typer.confirm")
-def test_confirm_default(mock_confirm):
-    """Default value is passed to typer.confirm."""
-    mock_confirm.return_value = True
-    confirm_action("Proceed?", default=True)
-    mock_confirm.assert_called_with("Proceed?", default=True)
+@patch("A.core.i18n.get_current_language")
+@patch("A.utils.interactive.typer.prompt")
+def test_confirm_yes_eo(mock_prompt, mock_lang):
+    """Esperanto: prompt has [j/n], entering 'j' returns True."""
+    mock_lang.return_value = "eo"
+    mock_prompt.return_value = "j"
+    assert confirm_action("Proceed?") is True
+    mock_prompt.assert_called_once_with("Proceed? [j/n]", default="n")
+
+
+@patch("A.core.i18n.get_current_language")
+@patch("A.utils.interactive.typer.prompt")
+def test_confirm_yes_fr(mock_prompt, mock_lang):
+    """French: prompt has [o/n], entering 'o' returns True."""
+    mock_lang.return_value = "fr"
+    mock_prompt.return_value = "o"
+    assert confirm_action("Proceed?") is True
+    mock_prompt.assert_called_once_with("Proceed? [o/n]", default="n")
+
+
+@patch("A.core.i18n.get_current_language")
+@patch("A.utils.interactive.typer.prompt")
+def test_confirm_default_true(mock_prompt, mock_lang):
+    """default=True: prompt default is the yes_char; empty input returns True."""
+    mock_lang.return_value = "en"
+    mock_prompt.return_value = ""
+    assert confirm_action("Proceed?", default=True) is True
+    mock_prompt.assert_called_once_with("Proceed? [y/n]", default="y")
+
+
+@patch("A.core.i18n.get_current_language")
+@patch("A.utils.interactive.typer.prompt")
+def test_confirm_default_false_empty(mock_prompt, mock_lang):
+    """default=False: prompt default is the no_char; empty input returns False."""
+    mock_lang.return_value = "en"
+    mock_prompt.return_value = ""
+    assert confirm_action("Proceed?", default=False) is False
+    mock_prompt.assert_called_once_with("Proceed? [y/n]", default="n")
+
+
+@patch("A.core.i18n.get_current_language")
+@patch("A.utils.interactive.typer.prompt")
+def test_confirm_yes_char_override(mock_prompt, mock_lang):
+    """yes_char overrides the language-based default prompt suffix."""
+    mock_lang.return_value = "eo"  # eo normally uses [j/n]
+    mock_prompt.return_value = "y"
+    assert confirm_action("Proceed?", yes_char="y") is True
+    mock_prompt.assert_called_once_with("Proceed? [y/n]", default="n")
+
+
+@patch("A.core.i18n.get_current_language")
+@patch("A.utils.interactive.typer.prompt")
+def test_confirm_no_char_override(mock_prompt, mock_lang):
+    """no_char overrides the language-based default prompt suffix."""
+    mock_lang.return_value = "en"  # en normally uses [y/n]
+    mock_prompt.return_value = "x"
+    assert confirm_action("Proceed?", no_char="x") is False
+    mock_prompt.assert_called_once_with("Proceed? [y/x]", default="x")
+
+
+@patch("A.core.i18n.get_current_language")
+@patch("A.utils.interactive.typer.prompt")
+def test_confirm_unknown_language_fallback(mock_prompt, mock_lang):
+    """Unsupported language falls back to [y/n]."""
+    mock_lang.return_value = "de"
+    mock_prompt.return_value = "y"
+    assert confirm_action("Proceed?") is True
+    mock_prompt.assert_called_once_with("Proceed? [y/n]", default="n")
+
+
+@patch("A.core.i18n.get_current_language")
+@patch("A.utils.interactive.typer.prompt")
+def test_confirm_retry_on_invalid(mock_prompt, mock_lang):
+    """Invalid input retries the prompt (loop continues until valid)."""
+    mock_lang.return_value = "en"
+    mock_prompt.side_effect = ["maybe", "y"]
+    assert confirm_action("Proceed?") is True
+    assert mock_prompt.call_count == 2


### PR DESCRIPTION
## Summary

Fixes #50 — two i18n bugs and several related issues discovered during codebase exploration.

### Bug 1: `confirm_action()` always shows `[y/n]` regardless of locale

**Fix:** Rewrote `confirm_action()` to use `typer.prompt()` with locale-aware suffix:
- `eo`: `[j/n]` (jes/ne)
- `en`: `[y/n]` (yes/no)
- `fr`: `[o/n]` (oui/non)

### Bug 2: `tr()` skips Esperanto in fallback chain

**Fix:** Changed fallback chain from `current_lang -> en -> key` to `current_lang -> eo -> en -> key`, making Esperanto the primary fallback language.

### Additional fixes
- Removed dead variable in `tr_multi()`
- Removed dead code in `_ensure_keyring()` (unreachable second try block)
- Replaced `typer.confirm()` with `confirm_action()` in `_ensure_keyring()`
- Wrapped hardcoded user-facing strings in `tr_multi()` across `cli.py` and `output.py`
- Fixed typos: 'migrationoj' -> 'migradoj', 'malsukoresis' -> 'malsukcesis'
- Updated `AGENTS.md` with documented i18n conventions and fallback rules
- Updated tests for new locale-aware `confirm_action()`

### Files changed
| File | Change |
|------|--------|
| `src/A/core/i18n.py` | `tr()` fallback chain + remove dead variable |
| `src/A/utils/interactive.py` | Locale-aware `confirm_action()` |
| `src/A/cli.py` | `tr_multi()` wrapping, dead code removal, `confirm_action()` usage |
| `src/A/utils/output.py` | `"Neniuj rezultoj."` wrapped in `tr_multi()` |
| `AGENTS.md` | Documented i18n conventions |
| `tests/test_interactive.py` | 10 new tests for locale-aware confirm |

Closes #50