### PR TITLE
fix: use prefix matching in FTS5 search queries (fixes #55)

### DIFF
--- a/src/A/data/search.py
+++ b/src/A/data/search.py
@@ -106,9 +106,9 @@ def build_search_query(
     else:
         normalized_query = query
 
-    # Escape FTS5 special characters and wrap in quotes for phrase matching
+    # Escape FTS5 special characters and use prefix matching
     escaped = normalized_query.replace('"', '""')
-    fts_query = f'"{escaped}"'
+    fts_query = f'"{escaped}"*'
 
     where_clauses = [f"{config.fts_table} MATCH ?"]
     params: list = [fts_query]


### PR DESCRIPTION
## Root Cause

In `A/data/search.py:111`, FTS5 queries used exact phrase matching (`"esp"`), which only matches the exact token "esp". Users typing partial words like "Esp" to find "Esperanto" got zero results.

## Fix

Changed from exact match to prefix match by appending `*`:

```python
# Before: "esp" → matches only token "esp"
# After:  "esp"* → matches tokens starting with "esp"
```

## Verification

| Query | Before | After |
|-------|--------|-------|
| `"esp"` | 0 results | — |
| `"esp"*` | — | 2 results (Esperanto, esprit) |
| `"fran"*` | — | 1 result (français) |
| `"pierre angulaire"*` | — | 1 result (pierre angulaire) |