### PR TITLE
feat: add get_property_details() with per-language labels (#82)

### DIFF
--- a/src/A/core/__init__.py
+++ b/src/A/core/__init__.py
@@ -19,6 +19,7 @@ from A.core.web import html_to_text, extract_text
 from A.core.wikidata import (
     COMMON_PROPERTIES,
     get_common_properties,
+    get_property_details,
     get_property_metadata,
     search_languages,
     search_properties,
@@ -107,6 +108,7 @@ __all__.extend(["html_to_text", "extract_text"])
 __all__.extend([
     "COMMON_PROPERTIES",
     "get_common_properties",
+    "get_property_details",
     "get_property_metadata",
     "search_languages",
     "search_properties",

--- a/src/A/core/wikidata/__init__.py
+++ b/src/A/core/wikidata/__init__.py
@@ -5,19 +5,28 @@ pre-seeded common properties dictionary for offline/quick access.
 
 Usage::
 
-    from A.core.wikidata import search_properties, get_property_metadata
+    from A.core.wikidata import (
+        search_properties,
+        get_property_metadata,
+        get_property_details,
+    )
 
     # Search Wikidata for properties matching a keyword
     results = search_properties("population", languages=["en", "eo"])
     for r in results:
         print(r["ligilo"], r["etikedo"])
 
-    # Get metadata for a specific property
+    # Get single best-match metadata
     meta = get_property_metadata("P1082", languages=["en", "eo"])
     print(meta["etikedo"], meta["priskribo"])
+
+    # Get per-language labels, descriptions, and aliases
+    details = get_property_details("P1082", languages=["en", "eo"])
+    print(details["labels"]["en"], details["labels"]["eo"])
 """
 
 from A.core.wikidata._client import (
+    get_property_details,
     get_property_metadata,
     search_languages,
     search_properties,
@@ -27,6 +36,7 @@ from A.core.wikidata._common import COMMON_PROPERTIES, get_common_properties
 __all__ = [
     "COMMON_PROPERTIES",
     "get_common_properties",
+    "get_property_details",
     "get_property_metadata",
     "search_languages",
     "search_properties",

--- a/src/A/core/wikidata/_client.py
+++ b/src/A/core/wikidata/_client.py
@@ -90,44 +90,102 @@ def _api_get(params: dict[str, str], *, timeout: float = 45.0) -> dict[str, Any]
     return data
 
 
+def _extract_all_language_metadata(
+    entity: dict[str, Any], *, prop_id: str
+) -> dict[str, Any]:
+    """Extract per-language labels, descriptions, and aliases from a Wikidata entity.
+
+    Unlike :func:`_extract_entity_metadata`, this returns *all* languages
+    present in the entity response without priority-based winnowing.
+
+    Returns:
+        dict with keys:
+            ``labels``       — ``{lang: str}``
+            ``descriptions`` — ``{lang: str}``
+            ``aliases``      — ``{lang: [str, ...]}``
+    """
+    labels: dict[str, str] = {}
+    raw_labels = entity.get("labels")
+    if isinstance(raw_labels, dict):
+        for lang, payload in raw_labels.items():
+            if isinstance(payload, dict) and str(payload.get("value") or "").strip():
+                labels[lang] = str(payload["value"]).strip()
+
+    descriptions: dict[str, str] = {}
+    raw_descs = entity.get("descriptions")
+    if isinstance(raw_descs, dict):
+        for lang, payload in raw_descs.items():
+            if isinstance(payload, dict) and str(payload.get("value") or "").strip():
+                descriptions[lang] = str(payload["value"]).strip()
+
+    aliases: dict[str, list[str]] = {}
+    raw_aliases = entity.get("aliases")
+    if isinstance(raw_aliases, dict):
+        for lang, entries in raw_aliases.items():
+            if not isinstance(entries, list):
+                continue
+            values: list[str] = []
+            seen: set[str] = set()
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                val = str(entry.get("value") or "").strip()
+                if val and val.lower() not in seen:
+                    seen.add(val.lower())
+                    values.append(val)
+            if values:
+                aliases[lang] = values
+
+    # Ensure prop_id appears in every language's alias list
+    prop_lower = prop_id.lower()
+    for lang in list(aliases):
+        if prop_lower not in {a.lower() for a in aliases[lang]}:
+            aliases[lang].append(prop_lower)
+    # If no language has aliases, seed the first available (or "en") with prop_id
+    alias_has_prop = any(
+        prop_lower in {a.lower() for a in al} for al in aliases.values()
+    )
+    if not alias_has_prop:
+        fallback_lang = next(iter(labels)) if labels else "en"
+        aliases.setdefault(fallback_lang, []).append(prop_lower)
+
+    return {"labels": labels, "descriptions": descriptions, "aliases": aliases}
+
+
 def _extract_entity_metadata(
     entity: dict[str, Any], *, prop_id: str, lang_list: list[str]
 ) -> dict[str, Any]:
     """Extract label, description, and aliases from a Wikidata entity dict.
 
+    Returns the **best match** per field using language priority.
+    For per-language data see :func:`_extract_all_language_metadata`.
+
     Returns dict with keys: etikedo, priskribo, aliasoj.
     """
-    labels = entity.get("labels")
-    descriptions = entity.get("descriptions")
-    aliases_obj = entity.get("aliases")
+    all_meta = _extract_all_language_metadata(entity, prop_id=prop_id)
+
     label = ""
+    for lang in lang_list:
+        if lang in all_meta["labels"]:
+            label = all_meta["labels"][lang]
+            break
+
     description = ""
-    if isinstance(labels, dict):
-        for lang in lang_list:
-            payload = labels.get(lang)
-            if isinstance(payload, dict) and str(payload.get("value") or "").strip():
-                label = str(payload.get("value") or "").strip()
-                break
-    if isinstance(descriptions, dict):
-        for lang in lang_list:
-            payload = descriptions.get(lang)
-            if isinstance(payload, dict) and str(payload.get("value") or "").strip():
-                description = str(payload.get("value") or "").strip()
-                break
+    for lang in lang_list:
+        if lang in all_meta["descriptions"]:
+            description = all_meta["descriptions"][lang]
+            break
+
     alias_values: list[str] = []
-    if isinstance(aliases_obj, dict):
-        for lang in lang_list:
-            payload = aliases_obj.get(lang)
-            if not isinstance(payload, list):
-                continue
-            for alias_entry in payload:
-                if not isinstance(alias_entry, dict):
-                    continue
-                value = str(alias_entry.get("value") or "").strip()
-                if value and value.lower() not in {a.lower() for a in alias_values}:
-                    alias_values.append(value)
-    if prop_id.lower() not in {alias.lower() for alias in alias_values}:
-        alias_values.append(prop_id.lower())
+    seen: set[str] = set()
+    for lang in lang_list:
+        if lang not in all_meta["aliases"]:
+            continue
+        for alias in all_meta["aliases"][lang]:
+            if alias.lower() not in seen:
+                seen.add(alias.lower())
+                alias_values.append(alias)
+
     return {"etikedo": label, "priskribo": description, "aliasoj": alias_values}
 
 
@@ -276,6 +334,56 @@ def _properties_metadata(
     return extracted
 
 
+def _properties_details(
+    prop_ids: list[str], languages: list[str] | None = None
+) -> dict[str, dict[str, Any]]:
+    """Fetch **per-language** metadata for multiple Wikidata properties.
+
+    Batch equivalent of :func:`get_property_details` — returns per-language
+    labels, descriptions, and aliases for all requested properties in a
+    single API call.
+
+    Args:
+        prop_ids: Wikidata property IDs (e.g. ``["P1082", "P31"]``).
+        languages: Language codes to return data for.
+            Defaults to ``["en", "eo"]``.
+
+    Returns:
+        ``{prop_id: {"labels": {...}, "descriptions": {...}, "aliases": {...}}}``
+
+    Raises:
+        RuntimeError: If the API is unreachable.
+    """
+    if languages is None:
+        languages = ["en", "eo"]
+    normalized: list[str] = []
+    for raw_id in prop_ids:
+        candidate = str(raw_id or "").strip().upper()
+        if re.fullmatch(r"P\d+", candidate) and candidate not in normalized:
+            normalized.append(candidate)
+    if not normalized:
+        return {}
+    lang_list = _language_priority(languages)
+    data = _api_get({
+        "action": "wbgetentities",
+        "format": "json",
+        "ids": "|".join(normalized),
+        "props": "labels|descriptions|aliases",
+        "languages": "|".join(lang_list),
+    })
+    entities = data.get("entities")
+    if not isinstance(entities, dict):
+        raise RuntimeError("Wikidata API respondo ne enhavas 'entities'")
+    extracted: dict[str, dict[str, Any]] = {}
+    for prop_id in normalized:
+        entity = entities.get(prop_id)
+        if isinstance(entity, dict):
+            extracted[prop_id] = _extract_all_language_metadata(
+                entity, prop_id=prop_id,
+            )
+    return extracted
+
+
 def get_property_metadata(
     prop_id: str, languages: list[str] | None = None
 ) -> dict[str, Any]:
@@ -310,3 +418,49 @@ def get_property_metadata(
     return _extract_entity_metadata(
         entity, prop_id=prop_id, lang_list=lang_list,
     )
+
+
+def get_property_details(
+    prop_id: str, languages: list[str] | None = None
+) -> dict[str, Any]:
+    """Fetch **per-language** labels, descriptions, and aliases for a Wikidata property.
+
+    Unlike :func:`get_property_metadata` which returns a single best-match,
+    this function returns data for *all requested languages* as a dict keyed
+    by language code.
+
+    Args:
+        prop_id: Wikidata property ID (e.g. ``"P1082"``).
+        languages: Language codes to return data for.
+            Defaults to ``["en", "eo"]``.
+
+    Returns:
+        ``{
+            "id": "P1082",
+            "labels": {"en": "population", "eo": "loĝantaro"},
+            "descriptions": {"en": "...", "eo": "..."},
+            "aliases": {"en": ["pop", "p1082"], "eo": ["loĝantaroj", "p1082"]}
+        }``
+
+    Raises:
+        RuntimeError: If the property is not found or API unreachable.
+    """
+    if languages is None:
+        languages = ["en", "eo"]
+    lang_list = _language_priority(languages)
+    data = _api_get({
+        "action": "wbgetentities",
+        "format": "json",
+        "ids": prop_id,
+        "props": "labels|descriptions|aliases",
+        "languages": "|".join(lang_list),
+    })
+    entities = data.get("entities")
+    if not isinstance(entities, dict):
+        raise RuntimeError("Wikidata API respondo ne enhavas 'entities'")
+    entity = entities.get(prop_id)
+    if not isinstance(entity, dict):
+        raise RuntimeError("Wikidata API respondo ne enhavas la petitan ID")
+    details = _extract_all_language_metadata(entity, prop_id=prop_id)
+    details["id"] = prop_id
+    return details

--- a/tests/test_wikidata.py
+++ b/tests/test_wikidata.py
@@ -9,14 +9,17 @@ import pytest
 from A.core.wikidata import (
     COMMON_PROPERTIES,
     get_common_properties,
+    get_property_details,
     get_property_metadata,
     search_languages,
     search_properties,
 )
 from A.core.wikidata._client import (
     _api_get,
+    _extract_all_language_metadata,
     _extract_entity_metadata,
     _language_priority,
+    _properties_details,
     _properties_metadata,
 )
 
@@ -218,6 +221,169 @@ class TestPropertiesMetadataMocked:
         result = _properties_metadata([], languages=["en"])
         assert result == {}
         mock_api.assert_not_called()
+
+
+# ── Per-language extraction ──────────────────────────────────────────────────
+
+
+class TestExtractAllLanguageMetadata:
+    def test_returns_per_language_labels(self) -> None:
+        entity = {
+            "labels": {"en": {"value": "Population"}, "eo": {"value": "Loĝantaro"}},
+            "descriptions": {"en": {"value": "number of inhabitants"}},
+            "aliases": {"en": [{"value": "pop"}], "eo": [{"value": "loĝantaroj"}]},
+        }
+        result = _extract_all_language_metadata(entity, prop_id="P1082")
+        assert result["labels"]["en"] == "Population"
+        assert result["labels"]["eo"] == "Loĝantaro"
+        assert result["descriptions"]["en"] == "number of inhabitants"
+        assert "pop" in result["aliases"]["en"]
+        assert "loĝantaroj" in result["aliases"]["eo"]
+
+    def test_prop_id_in_each_language_aliases(self) -> None:
+        entity = {
+            "labels": {"en": {"value": "Population"}},
+            "descriptions": {},
+            "aliases": {"en": [{"value": "pop"}], "eo": [{"value": "loĝantaroj"}]},
+        }
+        result = _extract_all_language_metadata(entity, prop_id="P1082")
+        assert "p1082" in [a.lower() for a in result["aliases"]["en"]]
+        assert "p1082" in [a.lower() for a in result["aliases"]["eo"]]
+
+    def test_seeds_alias_when_none_exist(self) -> None:
+        entity = {
+            "labels": {"en": {"value": "Population"}},
+            "descriptions": {},
+            "aliases": {},
+        }
+        result = _extract_all_language_metadata(entity, prop_id="P1082")
+        # Should seed "en" (the only language with labels) with prop_id
+        assert result["aliases"] == {"en": ["p1082"]}
+
+    def test_empty_entity(self) -> None:
+        result = _extract_all_language_metadata({}, prop_id="P1")
+        assert result["labels"] == {}
+        assert result["descriptions"] == {}
+        assert result["aliases"] == {"en": ["p1"]}
+
+    def test_handles_missing_keys(self) -> None:
+        result = _extract_all_language_metadata(
+            {"labels": None, "descriptions": None, "aliases": None},
+            prop_id="P1",
+        )
+        assert result["labels"] == {}
+        assert result["descriptions"] == {}
+
+
+# ── get_property_details (mocked) ────────────────────────────────────────────
+
+
+class TestGetPropertyDetailsMocked:
+    @patch("A.core.wikidata._client._api_get")
+    def test_returns_per_language_data(self, mock_api: MagicMock) -> None:
+        mock_api.return_value = {
+            "entities": {
+                "P1082": {
+                    "labels": {
+                        "en": {"value": "population"},
+                        "eo": {"value": "loĝantaro"},
+                    },
+                    "descriptions": {
+                        "en": {"value": "number of inhabitants"},
+                        "eo": {"value": "nombro da loĝantoj"},
+                    },
+                    "aliases": {
+                        "en": [{"value": "pop"}],
+                        "eo": [{"value": "loĝantaroj"}],
+                    },
+                },
+            },
+        }
+        result = get_property_details("P1082", languages=["en", "eo"])
+        assert result["id"] == "P1082"
+        assert result["labels"]["en"] == "population"
+        assert result["labels"]["eo"] == "loĝantaro"
+        assert result["descriptions"]["eo"] == "nombro da loĝantoj"
+        assert result["aliases"]["en"] == ["pop", "p1082"]
+        assert result["aliases"]["eo"] == ["loĝantaroj", "p1082"]
+
+    @patch("A.core.wikidata._client._api_get")
+    def test_missing_entity_raises(self, mock_api: MagicMock) -> None:
+        mock_api.return_value = {"entities": {}}
+        with pytest.raises(RuntimeError):
+            get_property_details("P999999", languages=["en"])
+
+    @patch("A.core.wikidata._client._api_get")
+    def test_single_language(self, mock_api: MagicMock) -> None:
+        mock_api.return_value = {
+            "entities": {
+                "P31": {
+                    "labels": {"en": {"value": "instance of"}},
+                    "descriptions": {},
+                    "aliases": {},
+                },
+            },
+        }
+        result = get_property_details("P31", languages=["en"])
+        assert result["labels"]["en"] == "instance of"
+        assert "en" not in result.get("descriptions", {})
+
+
+# ── _properties_details (mocked) ─────────────────────────────────────────────
+
+
+class TestPropertiesDetailsMocked:
+    @patch("A.core.wikidata._client._api_get")
+    def test_fetches_multiple(self, mock_api: MagicMock) -> None:
+        mock_api.return_value = {
+            "entities": {
+                "P31": {
+                    "labels": {
+                        "en": {"value": "instance of"},
+                        "eo": {"value": "estas ekzemplo de"},
+                    },
+                    "descriptions": {},
+                    "aliases": {},
+                },
+                "P279": {
+                    "labels": {
+                        "en": {"value": "subclass of"},
+                        "eo": {"value": "subklaso de"},
+                    },
+                    "descriptions": {},
+                    "aliases": {},
+                },
+            },
+        }
+        result = _properties_details(["P31", "P279"], languages=["en", "eo"])
+        assert "P31" in result
+        assert "P279" in result
+        assert result["P31"]["labels"]["en"] == "instance of"
+        assert result["P31"]["labels"]["eo"] == "estas ekzemplo de"
+        assert result["P279"]["labels"]["eo"] == "subklaso de"
+
+    @patch("A.core.wikidata._client._api_get")
+    def test_empty_ids(self, mock_api: MagicMock) -> None:
+        mock_api.return_value = {}
+        result = _properties_details([], languages=["en"])
+        assert result == {}
+        mock_api.assert_not_called()
+
+    @patch("A.core.wikidata._client._api_get")
+    def test_handles_partial_results(self, mock_api: MagicMock) -> None:
+        mock_api.return_value = {
+            "entities": {
+                "P31": {
+                    "labels": {"en": {"value": "instance of"}},
+                    "descriptions": {},
+                    "aliases": {},
+                },
+            },
+        }
+        # P279 is missing from the API response
+        result = _properties_details(["P31", "P279"], languages=["en"])
+        assert "P31" in result
+        assert "P279" not in result
 
 
 # ── Integration-style (no network) ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds `get_property_details()` to `A.core.wikidata` — a new public function that returns per-language labels, descriptions, and aliases for Wikidata properties in a **single API call**.

## Key Changes

- **`_extract_all_language_metadata()`** — new shared helper that extracts per-language data from a Wikidata entity dict (no priority-based winnowing)
- **`get_property_details()`** — new public function returning `{id, labels, descriptions, aliases}` with language-code keys
- **`_properties_details()`** — batch equivalent for multiple properties in one API call
- **Refactored `_extract_entity_metadata()`** — now delegates to the shared helper (behavior unchanged)

## Impact

- Eliminates the double-API-call workaround (currently A-semantika calls `get_property_metadata()` twice with swapped priorities)
- Backward compatible — `get_property_metadata()` unchanged
- Enables per-language label storage in A-module DB schemas

Closes #82