### PR TITLE
fix: confirm_action() prompt abbreviation reflects default parameter

### DIFF
--- a/src/A/utils/interactive.py
+++ b/src/A/utils/interactive.py
@@ -97,7 +97,9 @@ def confirm_action(
 ) -> bool:
     """Display a locale-aware yes/no confirmation prompt.
 
-    Shows [J/n] in Esperanto, [Y/n] in English, [O/n] in French.
+    Shows uppercase letter for the default option:
+    - default=True: [J/n] (eo), [Y/n] (en), [O/n] (fr)
+    - default=False: [j/N] (eo), [y/N] (en), [o/N] (fr)
     Accepts both the full word (jes/yes/oui) and single letter (j/y/o).
 
     Parameters
@@ -116,18 +118,21 @@ def confirm_action(
     lang = get_current_language()
 
     # Locale-specific prompt and accepted inputs
+    # Uppercase letter = default option per terminal convention
     if lang == "eo":
-        prompt_abbr = "[J/n]"
+        yes_letter, no_letter = ("J", "n") if default else ("j", "N")
         yes_words = {"j", "jes"}
         no_words = {"n", "ne"}
     elif lang == "fr":
-        prompt_abbr = "[O/n]"
+        yes_letter, no_letter = ("O", "n") if default else ("o", "N")
         yes_words = {"o", "oui"}
         no_words = {"n", "non"}
     else:
-        prompt_abbr = "[Y/n]"
+        yes_letter, no_letter = ("Y", "n") if default else ("y", "N")
         yes_words = {"y", "yes"}
         no_words = {"n", "no"}
+
+    prompt_abbr = f"[{yes_letter}/{no_letter}]"
 
     for _attempt in range(10):
         raw = typer.prompt(f"{message} {prompt_abbr}", default="").strip().lower()

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -169,3 +169,80 @@ def test_confirm_french():
     with _p("A.utils.interactive.typer.prompt", return_value="o"), \
          _p("A.core.i18n.get_current_language", return_value="fr"):
         assert confirm_action("Proceed?") is True
+
+
+def _capture_prompt_text(return_value: str = "") -> tuple[list[str], str]:
+    """Capture the prompt text passed to typer.prompt.
+
+    Returns (captured_texts, return_value) for use as side_effect.
+    """
+    captured: list[str] = []
+
+    def _side_effect(text: str, **kwargs: object) -> str:
+        captured.append(text)
+        return return_value
+
+    return captured, _side_effect  # type: ignore[return-value]
+
+
+# ── Prompt abbreviation tests ──────────────────────────────────────────────
+
+
+def test_prompt_abbrev_default_true_english():
+    """Shows [Y/n] when default=True in English."""
+    from unittest.mock import patch as _p
+    captured, side_effect = _capture_prompt_text("")
+    with _p("A.utils.interactive.typer.prompt", side_effect=side_effect), \
+         _p("A.core.i18n.get_current_language", return_value="en"):
+        confirm_action("Go?", default=True)
+    assert "[Y/n]" in captured[0]
+
+
+def test_prompt_abbrev_default_false_english():
+    """Shows [y/N] when default=False in English."""
+    from unittest.mock import patch as _p
+    captured, side_effect = _capture_prompt_text("")
+    with _p("A.utils.interactive.typer.prompt", side_effect=side_effect), \
+         _p("A.core.i18n.get_current_language", return_value="en"):
+        confirm_action("Go?", default=False)
+    assert "[y/N]" in captured[0]
+
+
+def test_prompt_abbrev_default_true_esperanto():
+    """Shows [J/n] when default=True in Esperanto."""
+    from unittest.mock import patch as _p
+    captured, side_effect = _capture_prompt_text("")
+    with _p("A.utils.interactive.typer.prompt", side_effect=side_effect), \
+         _p("A.core.i18n.get_current_language", return_value="eo"):
+        confirm_action("Go?", default=True)
+    assert "[J/n]" in captured[0]
+
+
+def test_prompt_abbrev_default_false_esperanto():
+    """Shows [j/N] when default=False in Esperanto."""
+    from unittest.mock import patch as _p
+    captured, side_effect = _capture_prompt_text("")
+    with _p("A.utils.interactive.typer.prompt", side_effect=side_effect), \
+         _p("A.core.i18n.get_current_language", return_value="eo"):
+        confirm_action("Go?", default=False)
+    assert "[j/N]" in captured[0]
+
+
+def test_prompt_abbrev_default_true_french():
+    """Shows [O/n] when default=True in French."""
+    from unittest.mock import patch as _p
+    captured, side_effect = _capture_prompt_text("")
+    with _p("A.utils.interactive.typer.prompt", side_effect=side_effect), \
+         _p("A.core.i18n.get_current_language", return_value="fr"):
+        confirm_action("Go?", default=True)
+    assert "[O/n]" in captured[0]
+
+
+def test_prompt_abbrev_default_false_french():
+    """Shows [o/N] when default=False in French."""
+    from unittest.mock import patch as _p
+    captured, side_effect = _capture_prompt_text("")
+    with _p("A.utils.interactive.typer.prompt", side_effect=side_effect), \
+         _p("A.core.i18n.get_current_language", return_value="fr"):
+        confirm_action("Go?", default=False)
+    assert "[o/N]" in captured[0]


### PR DESCRIPTION
## Summary

Fixes the root cause of A-semantika #14: the prompt abbreviation in `confirm_action()` always showed uppercase first letter regardless of the `default` parameter.

### Before
```
[Y/n]  ← always shown, even when default=False
```

### After
```
[Y/n]  ← when default=True (uppercase = default)
[y/N]  ← when default=False (lowercase = default)
```

### Changes
- `src/A/utils/interactive.py`: prompt_abbr now dynamically picks casing based on `default`
- `tests/test_interactive.py`: 6 new tests verifying abbreviation in all 3 locales (eo/en/fr)

A-semantika will be fixed in a companion PR (Ron-RONZZ-org/A-semantika#15).