### PR TITLE
feat: A_DIR env-var override for path functions (#87)

### DIFF
--- a/src/A/core/paths.py
+++ b/src/A/core/paths.py
@@ -1,29 +1,103 @@
-"""XDG path resolution."""
+"""XDG path resolution with optional ``A_DIR`` environment variable override.
 
+When the ``A_DIR`` environment variable is set, all four path functions
+return paths under ``$A_DIR / {data,config,cache,state}`` instead of
+their default XDG locations.
+
+Example::
+
+    export A_DIR=/tmp/my-project
+    python -c "from A.core.paths import data_dir; print(data_dir())"
+    # => /tmp/my-project/data
+"""
+
+import os
 from pathlib import Path
+
+_A_DIR_ENV = "A_DIR"
+
+
+def _base() -> Path | None:
+    """Return the base directory from ``A_DIR`` env var, or ``None``.
+
+    Reads the ``A_DIR`` environment variable on every call (lazy
+    evaluation).  Returns ``None`` when the variable is unset, empty,
+    or whitespace-only, preserving the default XDG resolution.
+    """
+    val = os.environ.get(_A_DIR_ENV, "").strip()
+    if not val:
+        return None
+    return Path(val).resolve()
 
 
 def data_dir() -> Path:
-    """Return data directory (~/.local/share/A)."""
+    """Return the A data directory.
+
+    Default::
+
+        ~/.local/share/A
+
+    When the ``A_DIR`` environment variable is set, returns
+    ``A_DIR / "data"`` instead.
+
+    The directory is **not** created automatically — call
+    :func:`ensure_dirs` or ``.mkdir(parents=True)`` explicitly.
+    """
+    base = _base()
+    if base is not None:
+        return base / "data"
     return Path.home() / ".local" / "share" / "A"
 
 
 def config_dir() -> Path:
-    """Return config directory (~/.config/A)."""
+    """Return the A config directory.
+
+    Default::
+
+        ~/.config/A
+
+    When the ``A_DIR`` environment variable is set, returns
+    ``A_DIR / "config"`` instead.
+    """
+    base = _base()
+    if base is not None:
+        return base / "config"
     return Path.home() / ".config" / "A"
 
 
 def cache_dir() -> Path:
-    """Return cache directory (~/.cache/A)."""
+    """Return the A cache directory.
+
+    Default::
+
+        ~/.cache/A
+
+    When the ``A_DIR`` environment variable is set, returns
+    ``A_DIR / "cache"`` instead.
+    """
+    base = _base()
+    if base is not None:
+        return base / "cache"
     return Path.home() / ".cache" / "A"
 
 
 def state_dir() -> Path:
-    """Return state directory (~/.local/state/A)."""
+    """Return the A state directory.
+
+    Default::
+
+        ~/.local/state/A
+
+    When the ``A_DIR`` environment variable is set, returns
+    ``A_DIR / "state"`` instead.
+    """
+    base = _base()
+    if base is not None:
+        return base / "state"
     return Path.home() / ".local" / "state" / "A"
 
 
 def ensure_dirs() -> None:
-    """Ensure all A directories exist."""
+    """Ensure all A directories exist (respects ``A_DIR`` override)."""
     for d in [data_dir(), config_dir(), cache_dir(), state_dir()]:
         d.mkdir(parents=True, exist_ok=True)

--- a/src/A/core/testing.py
+++ b/src/A/core/testing.py
@@ -23,28 +23,22 @@ import pytest
 def patch_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Redirect all A-core path functions to *tmp_path* subdirectories.
 
-    Call this **first** in your autouse fixture, before any module imports
-    that rely on resolved paths.  Handles the absence of ``@lru_cache``:
-    the original functions are simply replaced in the ``A.core.paths``
-    namespace.
-
-    Created subdirectories under *tmp_path*:
+    Sets the ``A_DIR`` environment variable so that every path function
+    returns a subdirectory under *tmp_path*:
 
     ============= ==================
-    Function      Redirected to
+    Function      Under ``A_DIR``
     ============= ==================
     ``data_dir``  ``tmp_path / "data"``
     ``config_dir`` ``tmp_path / "config"``
     ``cache_dir`` ``tmp_path / "cache"``
     ``state_dir`` ``tmp_path / "state"``
     ============= ==================
-    """
-    import A.core.paths as core_paths
 
-    monkeypatch.setattr(core_paths, "data_dir", lambda: tmp_path / "data")
-    monkeypatch.setattr(core_paths, "config_dir", lambda: tmp_path / "config")
-    monkeypatch.setattr(core_paths, "cache_dir", lambda: tmp_path / "cache")
-    monkeypatch.setattr(core_paths, "state_dir", lambda: tmp_path / "state")
+    Subdirectories are **not** pre-created (matches the lazy contract of
+    :func:`A.core.paths.ensure_dirs`).
+    """
+    monkeypatch.setenv("A_DIR", str(tmp_path))
 
 
 def patch_keyring(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,171 @@
+"""Tests for A.core.paths — A_DIR env var override & default XDG resolution."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from A.core.paths import (
+    _A_DIR_ENV,
+    _base,
+    cache_dir,
+    config_dir,
+    data_dir,
+    ensure_dirs,
+    state_dir,
+)
+
+# ── _base helper ────────────────────────────────────────────────────────────
+
+
+def test_base_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_base() returns None when A_DIR is not set."""
+    monkeypatch.delenv(_A_DIR_ENV, raising=False)
+    assert _base() is None
+
+
+def test_base_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_base() returns None when A_DIR is empty string."""
+    monkeypatch.setenv(_A_DIR_ENV, "")
+    assert _base() is None
+
+
+def test_base_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_base() returns None when A_DIR is whitespace-only."""
+    monkeypatch.setenv(_A_DIR_ENV, "   ")
+    assert _base() is None
+
+
+def test_base_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_base() returns resolved Path for a valid A_DIR."""
+    monkeypatch.setenv(_A_DIR_ENV, "/tmp/a-core-test")
+    result = _base()
+    assert isinstance(result, Path)
+    assert result == Path("/tmp/a-core-test").resolve()
+
+
+def test_base_relative(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_base() resolves relative paths to absolute."""
+    monkeypatch.setenv(_A_DIR_ENV, ".")
+    result = _base()
+    assert result.is_absolute()
+    assert result == Path.cwd().resolve()
+
+
+# ── Default (XDG) paths ────────────────────────────────────────────────────
+
+
+def test_default_data_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """data_dir() returns XDG default when A_DIR is unset."""
+    monkeypatch.delenv(_A_DIR_ENV, raising=False)
+    assert data_dir() == Path.home() / ".local" / "share" / "A"
+
+
+def test_default_config_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """config_dir() returns XDG default when A_DIR is unset."""
+    monkeypatch.delenv(_A_DIR_ENV, raising=False)
+    assert config_dir() == Path.home() / ".config" / "A"
+
+
+def test_default_cache_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """cache_dir() returns XDG default when A_DIR is unset."""
+    monkeypatch.delenv(_A_DIR_ENV, raising=False)
+    assert cache_dir() == Path.home() / ".cache" / "A"
+
+
+def test_default_state_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """state_dir() returns XDG default when A_DIR is unset."""
+    monkeypatch.delenv(_A_DIR_ENV, raising=False)
+    assert state_dir() == Path.home() / ".local" / "state" / "A"
+
+
+# ── A_DIR override ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "path_func, subdir",
+    [
+        (data_dir, "data"),
+        (config_dir, "config"),
+        (cache_dir, "cache"),
+        (state_dir, "state"),
+    ],
+)
+def test_override(
+    monkeypatch: pytest.MonkeyPatch,
+    path_func: callable,
+    subdir: str,
+) -> None:
+    """Each path function returns ``A_DIR / <subdir>`` when A_DIR is set."""
+    monkeypatch.setenv(_A_DIR_ENV, "/tmp/a-override")
+    expected = Path("/tmp/a-override").resolve() / subdir
+    assert path_func() == expected
+
+
+# ── Empty string treated as unset ──────────────────────────────────────────
+
+
+def test_empty_string_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty A_DIR falls back to XDG default."""
+    monkeypatch.setenv(_A_DIR_ENV, "")
+    assert data_dir() == Path.home() / ".local" / "share" / "A"
+    assert config_dir() == Path.home() / ".config" / "A"
+    assert cache_dir() == Path.home() / ".cache" / "A"
+    assert state_dir() == Path.home() / ".local" / "state" / "A"
+
+
+# ── Lazy evaluation ────────────────────────────────────────────────────────
+
+
+def test_lazy_evaluation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Changing A_DIR between calls changes the returned path."""
+    monkeypatch.setenv(_A_DIR_ENV, "/tmp/first")
+    assert data_dir() == Path("/tmp/first/data").resolve()
+
+    monkeypatch.setenv(_A_DIR_ENV, "/tmp/second")
+    assert data_dir() == Path("/tmp/second/data").resolve()
+
+
+# ── ensure_dirs ─────────────────────────────────────────────────────────────
+
+
+def test_ensure_dirs_respects_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """ensure_dirs() creates directories under the A_DIR override."""
+    monkeypatch.setenv(_A_DIR_ENV, str(tmp_path))
+    ensure_dirs()
+    assert (tmp_path / "data").is_dir()
+    assert (tmp_path / "config").is_dir()
+    assert (tmp_path / "cache").is_dir()
+    assert (tmp_path / "state").is_dir()
+
+
+def test_ensure_dirs_xdg(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """ensure_dirs() creates XDG directories when A_DIR is unset."""
+    monkeypatch.delenv(_A_DIR_ENV, raising=False)
+
+    # Monkey-patch home to avoid polluting real ~
+    fake_home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    ensure_dirs()
+    assert (fake_home / ".local" / "share" / "A").is_dir()
+    assert (fake_home / ".config" / "A").is_dir()
+    assert (fake_home / ".cache" / "A").is_dir()
+    assert (fake_home / ".local" / "state" / "A").is_dir()
+
+
+# ── patch_paths integration ─────────────────────────────────────────────────
+
+
+def test_patch_paths_isolates(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """patch_paths() redirects all paths under tmp_path."""
+    from A.core.testing import patch_paths
+
+    patch_paths(monkeypatch, tmp_path)
+    assert data_dir() == tmp_path / "data"
+    assert config_dir() == tmp_path / "config"
+    assert cache_dir() == tmp_path / "cache"
+    assert state_dir() == tmp_path / "state"


### PR DESCRIPTION
## Summary

Adds `A_DIR` environment variable override for `data_dir()`, `config_dir()`, `cache_dir()`, `state_dir()` in `A.core.paths`.

## Changes

### `src/A/core/paths.py`
- New `_base()` helper reads `A_DIR` env var (lazy eval per call)
- All 4 path functions check `A_DIR` first, fall back to XDG
- Empty/whitespace-only `A_DIR` treated as unset
- Relative paths resolved to absolute via `.resolve()`

### `src/A/core/testing.py`
- `patch_paths()` simplified: 4 monkeypatches → 1 `monkeypatch.setenv("A_DIR", ...)`

### `tests/test_paths.py` (new, 18 tests)
Covers: `_base()` helper, default XDG paths, A_DIR override (parametrized), empty string, lazy evaluation, ensure_dirs, patch_paths integration

## Design Decisions
- **Name `A_DIR`** (not `A_DATA_DIR`) — affects all 4 functions, not just data
- **No extra `A/` nesting** — `$A_DIR/data/` not `$A_DIR/A/data/`
- **Zero breaking change** — unset `A_DIR` = same XDG behavior as today

Closes #87