### PR TITLE
feat: uzanto profile with save_config fix and full CLI

### DIFF
--- a/src/A/core/config.py
+++ b/src/A/core/config.py
@@ -33,32 +33,55 @@ def load_config() -> Config:
     except Exception as e:
         raise ConfigError(f"failed to load config: {e}") from e
     
+    # Support both top-level format (legacy) and [A] section
+    root = data.get("A", data)
     return Config(
-        language=data.get("language", "eo"),
-        verbose=data.get("verbose", False),
-        plugins=data.get("plugins", []),
-        aliases=data.get("aliases", {}),
-        settings=data.get("settings", {}),
+        language=root.get("language", "eo"),
+        verbose=root.get("verbose", False),
+        plugins=root.get("plugins", []),
+        aliases=root.get("aliases", {}),
+        settings=root.get("settings", {}),
     )
 
 
 def save_config(config: Config) -> None:
-    """Save configuration to config.toml."""
+    """Save configuration to config.toml.
+
+    Uses tomlkit for proper TOML serialization, including nested
+    structures in the ``settings`` dict (lists, dicts, scalars).
+
+    Args:
+        config: The configuration to persist.
+    """
+    import tomlkit
+    from tomlkit import dumps
+
     config_path = config_dir() / "config.toml"
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    
-    # TOML doesn't support dataclass, manual write
-    lines = ["[A]", f"language = \"{config.language}\""]
+
+    doc = tomlkit.document()
+    doc["A"] = tomlkit.table()
+    doc["A"]["language"] = config.language
+
     if config.verbose:
-        lines.append("verbose = true")
+        doc["A"]["verbose"] = True
     if config.plugins:
-        lines.append(f"plugins = {config.plugins}")
+        arr = tomlkit.array()
+        for p in config.plugins:
+            arr.append(p)
+        doc["A"]["plugins"] = arr
     if config.aliases:
-        lines.append("[A.aliases]")
+        aliases = tomlkit.table()
         for k, v in config.aliases.items():
-            lines.append(f'{k} = "{v}"')
-    
-    config_path.write_text("\n".join(lines) + "\n")
+            aliases[k] = v
+        doc["A"]["aliases"] = aliases
+    if config.settings:
+        settings = tomlkit.table()
+        for k, v in config.settings.items():
+            settings[k] = v
+        doc["A"]["settings"] = settings
+
+    config_path.write_text(dumps(doc), encoding="utf-8")
 
 
 # User profile methods

--- a/src/A/core/uzanto_cli.py
+++ b/src/A/core/uzanto_cli.py
@@ -1,10 +1,11 @@
 """Uzanto — user profile management CLI, ported from autish-legacy.
 
 Usage:
-    A uzanto vidi              — view profile
-    A uzanto modifi            — modify profile fields
-    A uzanto eksporti <file>   — export profile to JSON
-    A uzanto importi <file>    — import profile from JSON
+    A uzanto vidi                          — view profile
+    A uzanto modifi [opcioj...]            — modify profile fields
+    A uzanto eksporti <file> [--pasvorto]  — export profile
+    A uzanto importi <file> [--pasvorto]   — import profile
+    A uzanto pasvorto [--forigi]           — set/remove master password
 """
 
 from __future__ import annotations
@@ -21,205 +22,336 @@ from A import tr, tr_multi
 from A.console import console
 from A.utils import info, error, success
 from A.core.config import load_config, save_config
+from A.core.paths import config_dir
+from A.core.uzanto_service import (
+    load_profile, save_profile,
+    get_master_password, set_master_password, delete_master_password,
+    get_huggingface_api_key, set_huggingface_api_key,
+    encrypt_profile, decrypt_profile,
+    validate_date, normalize_multi_contact,
+    display_value, mask_api_key, _STANDARD_FIELDS,
+)
 
+_H = tr_multi  # short alias for the help-text helper
 app = typer.Typer(
     name="uzanto",
-    help=tr_multi(
-        "Uzanto — administri uzantprofilon",
-        "User — manage user profile",
-        "Utilisateur — gérer le profil utilisateur",
-    ),
+    help=_H("Administri uzantprofilon", "Manage user profile", "Gérer le profil"),
     no_args_is_help=True,
     context_settings={"help_option_names": ["-h", "--help", "--helpo"]},
 )
 
-# Standard profile fields (stored in config settings)
-# Matching autish-legacy: nomo, familia_nomo, naskig_dato, lingvoj, ...
-_PROFILE_FIELDS: tuple[str, ...] = (
-    "nomo", "familia_nomo", "naskig_dato", "naskig_loko",
-    "lingvoj", "organizo", "telefonnumeroj", "retposhtadresoj",
-)
-
 
 def _cfg_path() -> Path:
-    """Return path to user config file."""
-    from A.core.paths import config_dir
     return config_dir() / "config.toml"
 
 
-def _display_val(val: object) -> str:
-    """Format a profile value for display."""
-    if val is None:
-        return "-"
-    if isinstance(val, list):
-        return ", ".join(str(v) for v in val)
-    return str(val)
+# ── vidi ────────────────────────────────────────────────────────────────────
 
 
 @app.command("vidi")
 def vidi() -> None:
     """View current user profile configuration."""
     cfg = load_config()
+    profile = load_profile()
 
     table = Table(show_header=False, box=BOX_SIMPLE)
-    table.add_column(tr_multi("Kampo", "Field", "Champ"), style="bold")
-    table.add_column(tr_multi("Valoro", "Value", "Valeur"))
+    table.add_column(_H("Kampo", "Field", "Champ"), style="bold")
+    table.add_column(_H("Valoro", "Value", "Valeur"))
 
-    # Core config fields
-    table.add_row(tr_multi("Lingvo", "Language", "Langue"), cfg.language or "-")
-    table.add_row(tr_multi("Dosiero", "Config file", "Fichier"), str(_cfg_path()))
+    table.add_row(_H("Lingvo", "Language", "Langue"), cfg.language or "-")
+    table.add_row(_H("Dosiero", "Config file", "Fichier"), str(_cfg_path()))
 
-    # Profile fields (from settings)
-    for field in _PROFILE_FIELDS:
-        val = cfg.settings.get(field)
+    pw = get_master_password()
+    pw_s = _H("Agordita", "Set", "Défini") if pw else _H("Ne agordita", "Not set", "Non défini")
+    table.add_row(_H("Ĉefpasvorto", "Master pwd", "Mdp maître"), pw_s)
+
+    hf = get_huggingface_api_key()
+    table.add_row("api_slosilo_huggingface", mask_api_key(hf) if hf else "-")
+
+    for field in _STANDARD_FIELDS:
+        if field == "api_slosilo_huggingface":
+            continue
+        val = profile.get(field)
         if val is not None:
-            table.add_row(field, _display_val(val))
+            table.add_row(field, display_value(val))
 
+    kampoj = profile.get("kampoj", {})
+    if isinstance(kampoj, dict):
+        for k, v in kampoj.items():
+            table.add_row(f"[kampoj] {k}", str(v))
     console.print(table)
+
+
+# ── modifi ──────────────────────────────────────────────────────────────────
 
 
 @app.command("modifi")
 def modifi(
-    lingvo: Optional[str] = typer.Option(
-        None, "--lingvo", "-l",
-        help=tr_multi("Lingva kodo (ekz: eo, en, fr)", "Language code (e.g. eo, en, fr)", "Code de langue (ex: eo, en, fr)"),
-    ),
-    nomo: Optional[str] = typer.Option(
-        None, "--nomo", "-n",
-        help=tr_multi("Nomo", "First name", "Prénom"),
-    ),
-    familia_nomo: Optional[str] = typer.Option(
-        None, "--familia-nomo", "-fn",
-        help=tr_multi("Familia nomo", "Family name", "Nom de famille"),
-    ),
-    naskig_dato: Optional[str] = typer.Option(
-        None, "--naskig-dato", "-nd",
-        help=tr_multi("Naskiĝdato (YYYY-MM-DD)", "Date of birth (YYYY-MM-DD)", "Date de naissance (AAAA-MM-JJ)"),
-    ),
-    naskig_loko: Optional[str] = typer.Option(
-        None, "--naskig-loko", "-nl",
-        help=tr_multi("Naskiĝloko", "Place of birth", "Lieu de naissance"),
-    ),
-    lingvoj: Optional[str] = typer.Option(
-        None, "--lingvoj", "-L",
-        help=tr_multi("Lingvoj (komo-disigitaj, ekz: eo,en,fr)", "Languages (comma-separated, e.g. eo,en,fr)", "Langues (séparées par des virgules, ex: eo,en,fr)"),
-    ),
-    organizo: Optional[str] = typer.Option(
-        None, "--organizo", "-o",
-        help=tr_multi("Organizo", "Organization", "Organisation"),
-    ),
+    lingvo: Optional[str] = typer.Option(None, "--lingvo", "-l",
+        help=_H("Lingva kodo (ekz: eo,en,fr)", "Language code (eo,en,fr)", "Code langue (ex: eo,en,fr)")),
+    nomo: Optional[str] = typer.Option(None, "--nomo", "-n",
+        help=_H("Nomo", "First name", "Prénom")),
+    familia_nomo: Optional[str] = typer.Option(None, "--familia-nomo", "-fn",
+        help=_H("Familia nomo", "Family name", "Nom famille")),
+    naskig_dato: Optional[str] = typer.Option(None, "--naskig-dato", "-nd",
+        help=_H("Naskiĝdato (YYYY-MM-DD)", "Birth date (YYYY-MM-DD)", "Date naissance (AAAA-MM-JJ)")),
+    naskig_loko: Optional[str] = typer.Option(None, "--naskig-loko", "-nl",
+        help=_H("Naskiĝloko", "Place of birth", "Lieu naissance")),
+    lingvoj: Optional[str] = typer.Option(None, "--lingvoj", "-L",
+        help=_H("Lingvoj (komo-disigitaj)", "Languages (comma-sep.)", "Langues (séparées par virgules)")),
+    organizo: Optional[str] = typer.Option(None, "--organizo", "-o",
+        help=_H("Organizo", "Organization", "Organisation")),
+    organiza_identiga_numero: Optional[str] = typer.Option(None, "--organiza-identiga-numero", "-oin",
+        help=_H("Org. identiga numero", "Org. identifier", "ID organisation")),
+    telefonnumero: Optional[list[str]] = typer.Option(None, "--telefonnumero", "-tel",
+        help=_H("Tel. formato valoro:etikedo:prima (ripetebla)", "Phone value:label:primary (repeatable)", "Tél. format valeur:étiquette:primaire")),
+    retposhtadreso: Optional[list[str]] = typer.Option(None, "--retposhtadreso", "-ret",
+        help=_H("Retposhto formato adreso:etikedo:prima (ripetebla)", "Email address:label:primary (repeatable)", "Email format adresse:étiquette:primaire")),
+    api_slosilo_huggingface: Optional[str] = typer.Option(None, "--api-slosilo-huggingface", "-a",
+        help=_H("HF API-ŝlosilo (konservita en keyring)", "HF API key (stored in keyring)", "Clé API HF (stockée keyring)")),
+    kampo: Optional[list[str]] = typer.Option(None, "--kampo", "-k",
+        help=_H("Propra kampo KEY:VALUE (ripetebla)", "Custom field KEY:VALUE (repeatable)", "Champ perso CLÉ:VALEUR (répétable)")),
 ) -> None:
-    """Modify user profile settings."""
+    """Modify user profile fields."""
     cfg = load_config()
+    profile = load_profile()
     changed = False
 
-    # Core config fields
+    # Language
     if lingvo is not None:
         if len(lingvo) != 2 or not lingvo.isalpha():
-            error(tr_multi(
-                f"Nevalida lingvokodo: '{lingvo}'. Uzu 2-literan kodon (ekz: eo, en, fr).",
-                f"Invalid language code: '{lingvo}'. Use a 2-letter code (e.g. eo, en, fr).",
-                f"Code de langue invalide : '{lingvo}'. Utilisez un code à 2 lettres (ex: eo, en, fr).",
-            ))
+            error(_H(f"Nevalida lingvokodo: '{lingvo}'.",
+                     f"Invalid language code: '{lingvo}'.",
+                     f"Code langue invalide : '{lingvo}'."))
             raise typer.Exit(1)
         cfg.language = lingvo.lower()
         changed = True
-        info(tr_multi(f"Lingvo → {lingvo}", f"Language → {lingvo}", f"Langue → {lingvo}"))
+        info(f"language → {lingvo}")
 
-    # Profile fields (stored in settings)
-    _str_fields = {
+    # Simple string fields
+    str_fields = {
         "nomo": nomo, "familia_nomo": familia_nomo,
         "naskig_dato": naskig_dato, "naskig_loko": naskig_loko,
         "organizo": organizo,
+        "organiza_identiga_numero": organiza_identiga_numero,
     }
-    for key, val in _str_fields.items():
-        if val is not None:
-            cfg.settings[key] = val
-            changed = True
-            info(f"{key} → {val}")
+    for key, val in str_fields.items():
+        if val is None:
+            continue
+        if key == "naskig_dato" and not validate_date(val):
+            error(_H(f"Nevalida dato: '{val}'. Uzu YYYY-MM-DD.",
+                     f"Invalid date: '{val}'. Use YYYY-MM-DD.",
+                     f"Date invalide : '{val}'. Utilisez AAAA-MM-JJ."))
+            raise typer.Exit(1)
+        profile[key] = val
+        changed = True
+        info(f"{key} → {val}")
 
+    # Languages list
     if lingvoj is not None:
         codes = [c.strip().lower() for c in lingvoj.split(",") if c.strip()]
         valid = [c for c in codes if len(c) == 2 and c.isalpha()]
         if valid:
-            cfg.settings["lingvoj"] = valid
+            profile["lingvoj"] = valid
             changed = True
-            info(tr_multi(
-                f"Lingvoj → {', '.join(valid)}",
-                f"Languages → {', '.join(valid)}",
-                f"Langues → {', '.join(valid)}",
-            ))
+            info(f"lingvoj → {', '.join(valid)}")
+
+    # Phone numbers (structured)
+    if telefonnumero is not None:
+        try:
+            profile["telefonnumeroj"] = normalize_multi_contact(telefonnumero, kind="telefono")
+            changed = True
+            info(f"telefonnumeroj → {len(telefonnumero)} entriĝoj")
+        except ValueError as exc:
+            error(str(exc))
+            raise typer.Exit(1)
+
+    # Email addresses (structured)
+    if retposhtadreso is not None:
+        try:
+            profile["retposhtadresoj"] = normalize_multi_contact(retposhtadreso, kind="retposhto")
+            changed = True
+            info(f"retposhtadresoj → {len(retposhtadreso)} entriĝoj")
+        except ValueError as exc:
+            error(str(exc))
+            raise typer.Exit(1)
+
+    # HuggingFace API key (keyring)
+    if api_slosilo_huggingface is not None:
+        if api_slosilo_huggingface.strip():
+            set_huggingface_api_key(api_slosilo_huggingface.strip())
+            profile["api_slosilo_huggingface"] = True
+            info(_H("HF API-ŝlosilo konservita.", "HF API key saved.", "Clé API HF enregistrée."))
+        else:
+            delete_master_password()
+            profile.pop("api_slosilo_huggingface", None)
+            info(_H("HF API-ŝlosilo forigita.", "HF API key removed.", "Clé API HF supprimée."))
+        changed = True
+
+    # Custom fields (kampoj)
+    if kampo:
+        if "kampoj" not in profile or not isinstance(profile["kampoj"], dict):
+            profile["kampoj"] = {}
+        for entry in kampo:
+            if ":" not in entry:
+                error(_H(f"Nevalida formato: '{entry}'. Uzu KEY:VALUE.",
+                         f"Invalid format: '{entry}'. Use KEY:VALUE.",
+                         f"Format invalide : '{entry}'. Utilisez CLÉ:VALEUR."))
+                raise typer.Exit(1)
+            k, _, v = entry.partition(":")
+            profile["kampoj"][k.strip()] = v.strip()
+            changed = True
+            info(f"kampo {k.strip()} → {v.strip()}")
 
     if not changed:
-        info(tr_multi(
-            "Neniuj ŝanĝoj. Uzu 'A uzanto modifi --help' por vidi opciojn.",
-            "No changes. Use 'A uzanto modifi --help' to see options.",
-            "Aucun changement. Utilisez 'A uzanto modifi --help' pour voir les options.",
-        ))
+        info(_H("Neniuj ŝanĝoj. Uzu --help por opcioj.",
+                "No changes. Use --help for options.",
+                "Aucun changement. Utilisez --help."))
         return
 
+    # Merge profile into cfg.settings and save once (avoids double-save bug)
+    cfg.settings.clear()
+    cfg.settings.update(profile)
     save_config(cfg)
-    success(tr_multi("Profilo ĝisdatigita.", "Profile updated.", "Profil mis à jour."))
+    success(_H("Profilo ĝisdatigita.", "Profile updated.", "Profil mis à jour."))
+
+
+# ── eksporti ────────────────────────────────────────────────────────────────
 
 
 @app.command("eksporti")
 def eksporti(
-    celo: str = typer.Argument(
-        ...,
-        help=tr_multi("Eliga JSON-dosiero", "Output JSON file", "Fichier JSON de sortie"),
-    ),
+    celo: str = typer.Argument(..., help=_H("Eliga dosiervojo", "Output path", "Chemin sortie")),
+    pasvorto: Optional[str] = typer.Option(None, "--pasvorto", "-p",
+        help=_H("Ĉifra pasvorto", "Encryption password", "Mot passe chiffrement")),
 ) -> None:
-    """Export user profile to JSON file."""
+    """Export profile to JSON (optionally encrypted)."""
     cfg = load_config()
-    profile = {
-        "language": cfg.language,
-        "profile": {f: cfg.settings.get(f) for f in _PROFILE_FIELDS if cfg.settings.get(f) is not None},
-    }
+    profile = load_profile()
+    data = {"language": cfg.language, "profile": profile}
+
     path = Path(celo).expanduser().resolve()
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(profile, indent=2, ensure_ascii=False), encoding="utf-8")
-    success(tr_multi(
-        f"Profielo eksportita al {path}",
-        f"Profile exported to {path}",
-        f"Profil exporté vers {path}",
-    ))
+
+    encrypt = pasvorto is not None
+    if pasvorto is None:
+        raw = typer.prompt(_H("Ĉu ĉifri? (j/N)", "Encrypt? (y/N)", "Chiffrer ? (o/N)"), default="n")
+        encrypt = raw.strip().lower()[:1] in ("j", "y", "o")
+        if encrypt:
+            pasvorto = typer.prompt(_H("Pasvorto", "Password", "Mot passe"), hide_input=True, confirmation_prompt=True)
+
+    if encrypt and pasvorto:
+        blob = encrypt_profile(data, pasvorto)
+        path.write_bytes(blob)
+        status = _H("(ĉifrita)", "(encrypted)", "(chiffré)")
+    else:
+        path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        status = _H("(necifrita)", "(plain)", "(non chiffré)")
+
+    success(_H(f"Profielo eksportita al {path} {status}.",
+               f"Profile exported to {path} {status}.",
+               f"Profil exporté vers {path} {status}."))
+
+
+# ── importi ─────────────────────────────────────────────────────────────────
 
 
 @app.command("importi")
 def importi(
-    fonto: str = typer.Argument(
-        ...,
-        help=tr_multi("Eniga JSON-dosiero", "Input JSON file", "Fichier JSON d'entrée"),
-    ),
+    fonto: str = typer.Argument(..., help=_H("Eniga dosiervojo", "Input path", "Chemin entrée")),
+    pasvorto: Optional[str] = typer.Option(None, "--pasvorto", "-p",
+        help=_H("Malĉifra pasvorto", "Decryption password", "Mot passe déchiffrement")),
+    anstatauigi: bool = typer.Option(False, "--anstatauigi", "-A",
+        help=_H("Anstataŭigi sen konfirmo", "Overwrite w/o confirm", "Remplacer sans confirmer")),
 ) -> None:
-    """Import user profile from JSON file."""
+    """Import profile from JSON (or encrypted) file."""
     path = Path(fonto).expanduser().resolve()
     if not path.exists():
-        error(tr_multi(
-            f"Dosiero ne trovita: {path}",
-            f"File not found: {path}",
-            f"Fichier non trouvé: {path}",
-        ))
+        error(_H(f"Dosiero ne trovita: {path}", f"File not found: {path}", f"Fichier non trouvé: {path}"))
         raise typer.Exit(1)
 
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as e:
-        error(str(e))
+    data: dict | None = None
+    if pasvorto:
+        data = _try_decrypt(path, pasvorto)
+    else:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            pw = typer.prompt(_H("Ŝajnas ĉifrita. Pasvorto:", "Encrypted file. Password:", "Fichier chiffré. Mot passe :"), hide_input=True)
+            if pw:
+                data = _try_decrypt(path, pw)
+
+    if not isinstance(data, dict):
+        error(_H("Nevalida dosierformato.", "Invalid file format.", "Format fichier invalide."))
         raise typer.Exit(1)
+
+    if load_profile() and not anstatauigi:
+        typed = typer.prompt(
+            _H("Tajpu 'anstataŭigi' por konfirmi", "Type 'overwrite' to confirm", "Tapez 'remplacer' pour confirmer")
+        ).strip().lower()
+        if typed not in ("anstataŭigi", "anstatauxigi", "overwrite", "remplacer"):
+            info(_H("Nuligita.", "Cancelled.", "Annulé."))
+            return
 
     cfg = load_config()
     if "language" in data:
         cfg.language = data["language"]
     if "profile" in data and isinstance(data["profile"], dict):
+        cfg.settings.clear()
         cfg.settings.update(data["profile"])
     save_config(cfg)
+    success(_H(f"Profielo importita el {path}", f"Profile imported from {path}", f"Profil importé depuis {path}"))
 
-    success(tr_multi(
-        f"Profielo importita el {path}",
-        f"Profile imported from {path}",
-        f"Profil importé depuis {path}",
-    ))
+
+def _try_decrypt(path: Path, password: str) -> dict | None:
+    """Attempt to decrypt and parse a profile file.
+
+    Returns None if decryption fails.
+    """
+    try:
+        raw = path.read_bytes()
+        return decrypt_profile(raw, password)
+    except Exception as e:
+        error(_H(f"Malĉifrado malsukcesis: {e}", f"Decryption failed: {e}", f"Échec déchiffrement : {e}"))
+        raise typer.Exit(1)
+
+
+# ── pasvorto ────────────────────────────────────────────────────────────────
+
+
+@app.command("pasvorto")
+def pasvorto_cmd(
+    forigi: bool = typer.Option(False, "--forigi", "-f",
+        help=_H("Forigi la ĉefpasvorton", "Remove master password", "Supprimer mot passe maître")),
+) -> None:
+    """Set or remove the user master password (for profile encryption)."""
+    old = get_master_password()
+
+    if forigi:
+        if not old:
+            error(_H("Neniu ĉefpasvorto agordita.", "No master password set.", "Aucun mot passe maître."))
+            raise typer.Exit(1)
+        c = typer.prompt(_H("Tajpu 'konfirmi' por forigi", "Type 'confirm' to remove", "Tapez 'confirmer'")).strip()
+        if c.lower() != "konfirmi":
+            info(_H("Nuligita.", "Cancelled.", "Annulé."))
+            return
+        delete_master_password()
+        success(_H("Ĉefpasvorto forigita.", "Master password removed.", "Mot passe maître supprimé."))
+        return
+
+    if old:
+        e = typer.prompt(_H("Nuna ĉefpasvorto", "Current master password", "Mot passe actuel"), hide_input=True)
+        if e != old:
+            error(_H("Malĝusta pasvorto.", "Wrong password.", "Mot passe incorrect."))
+            raise typer.Exit(1)
+
+    new = typer.prompt(_H("Nova ĉefpasvorto", "New master password", "Nouveau mot passe"), hide_input=True, confirmation_prompt=True)
+    if len(new) < 6:
+        error(_H("Pasvorto ≥ 6 signoj.", "Password ≥ 6 chars.", "Mot passe ≥ 6 car."))
+        raise typer.Exit(1)
+
+    set_master_password(new)
+    success(_H("Ĉefpasvorto agordita.", "Master password set.", "Mot passe maître défini."))
 
 
 __all__ = ["app"]

--- a/src/A/core/uzanto_service.py
+++ b/src/A/core/uzanto_service.py
@@ -1,0 +1,314 @@
+"""User profile service — load, save, validate, encrypt profile data.
+
+Provides the business-logic layer for the ``uzanto`` CLI, separating
+data access, validation, and encryption from command dispatch.
+
+Usage::
+
+    from A.core.uzanto_service import (
+        load_profile, save_profile,
+        get_master_password, set_master_password, delete_master_password,
+        encrypt_profile, decrypt_profile,
+        normalize_multi_contact, validate_date,
+    )
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from A.core.config import load_config, save_config
+from A.core.crypto import encrypt, decrypt
+from A.core.keyring import get_password, set_password, delete_password
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+_KEYRING_SERVICE = "A-uzanto"
+_KEYRING_KEY = "master"
+_KEYRING_API_SERVICE = "A-uzanto"
+_KEYRING_API_KEY = "huggingface-api-key"
+
+_STANDARD_FIELDS: tuple[str, ...] = (
+    "nomo",
+    "familia_nomo",
+    "naskig_dato",
+    "naskig_loko",
+    "lingvoj",
+    "organizo",
+    "organiza_identiga_numero",
+    "telefonnumeroj",
+    "retposhtadresoj",
+    "api_slosilo_huggingface",
+)
+
+# ── Profile load / save ──────────────────────────────────────────────────────
+
+
+def load_profile() -> dict[str, Any]:
+    """Load user profile from config settings.
+
+    Returns:
+        Dict of profile fields (may be empty if none configured).
+    """
+    cfg = load_config()
+    return dict(cfg.settings)
+
+
+def save_profile(profile: dict[str, Any]) -> None:
+    """Persist user profile to config settings.
+
+    Replaces the entire settings dict with the given profile data.
+
+    Args:
+        profile: Dict of profile fields to persist.
+    """
+    cfg = load_config()
+    cfg.settings.clear()
+    cfg.settings.update(profile)
+    save_config(cfg)
+
+
+# ── Master password (system keyring) ─────────────────────────────────────────
+
+
+def get_master_password() -> str | None:
+    """Retrieve master password from system keyring.
+
+    Returns:
+        The stored password, or ``None`` if not set or keyring unavailable.
+    """
+    return get_password(_KEYRING_SERVICE, _KEYRING_KEY)
+
+
+def set_master_password(password: str) -> bool:
+    """Store master password in system keyring.
+
+    Args:
+        password: The password to store.
+
+    Returns:
+        ``True`` if stored successfully.
+    """
+    return set_password(_KEYRING_SERVICE, _KEYRING_KEY, password)
+
+
+def delete_master_password() -> bool:
+    """Remove master password from system keyring (idempotent).
+
+    Returns:
+        ``True`` if removed or already absent.
+    """
+    return delete_password(_KEYRING_SERVICE, _KEYRING_KEY)
+
+
+# ── HuggingFace API key (system keyring) ────────────────────────────────────
+
+
+def get_huggingface_api_key() -> str | None:
+    """Retrieve HuggingFace API key from system keyring.
+
+    Consistent with :func:`A.core.ai.save_api_key`.
+
+    Returns:
+        The stored API key, or ``None``.
+    """
+    return get_password(_KEYRING_API_SERVICE, _KEYRING_API_KEY)
+
+
+def set_huggingface_api_key(api_key: str) -> bool:
+    """Store HuggingFace API key in system keyring.
+
+    Args:
+        api_key: The API key to store.
+
+    Returns:
+        ``True`` if stored successfully.
+    """
+    return set_password(_KEYRING_API_SERVICE, _KEYRING_API_KEY, api_key)
+
+
+def delete_huggingface_api_key() -> bool:
+    """Remove HuggingFace API key from system keyring.
+
+    Returns:
+        ``True`` if removed or already absent.
+    """
+    return delete_password(_KEYRING_API_SERVICE, _KEYRING_API_KEY)
+
+
+# ── Profile encryption / decryption ─────────────────────────────────────────
+
+
+def encrypt_profile(data: dict[str, Any], password: str) -> bytes:
+    """Encrypt profile data with a password (AES-256-GCM).
+
+    Args:
+        data: Profile dict to encrypt.
+        password: Encryption password.
+
+    Returns:
+        Encrypted binary blob.
+    """
+    plaintext = json.dumps(data, ensure_ascii=False).encode("utf-8")
+    return encrypt(plaintext, password)
+
+
+def decrypt_profile(blob: bytes, password: str) -> dict[str, Any]:
+    """Decrypt profile data with a password.
+
+    Args:
+        blob: Encrypted binary blob from :func:`encrypt_profile`.
+        password: Decryption password.
+
+    Returns:
+        Decrypted profile dict.
+
+    Raises:
+        ValueError: If the password is wrong or data is corrupt.
+    """
+    plaintext = decrypt(blob, password)
+    return json.loads(plaintext.decode("utf-8"))
+
+
+# ── Validation ───────────────────────────────────────────────────────────────
+
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_PHONE_RE = re.compile(r"^00\d{2,15}\d+$")
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def validate_date(value: str) -> bool:
+    """Check whether a string is a valid ``YYYY-MM-DD`` date.
+
+    Args:
+        value: Date string to validate.
+
+    Returns:
+        ``True`` if the format matches.
+    """
+    return bool(_DATE_RE.match(value))
+
+
+def normalize_multi_contact(items: list[str], *, kind: str) -> list[dict[str, Any]]:
+    """Parse structured multi-contact items from ``valoro:etikedo:prima`` format.
+
+    Each item follows the legacy autish format::
+
+        value:label:primary
+
+    Only ``value`` is required. When no label is supplied the item is
+    marked as primary with label ``"ĉefa"``.
+
+    Args:
+        items: List of raw strings in ``valoro:etikedo[:prima]`` format.
+        kind: ``"telefono"`` or ``"retposhto"`` — drives format validation.
+
+    Returns:
+        List of dicts with keys ``valoro``, ``etikedo``, ``prima``.
+
+    Raises:
+        ValueError: If any item fails format or validation rules.
+    """
+    out: list[dict[str, Any]] = []
+    for raw in items:
+        parts = [p.strip() for p in raw.split(":")]
+        if len(parts) < 1:
+            raise ValueError(f"Invalid format: {raw!r}. Expected valoro:etikedo[:prima]")
+
+        value = parts[0]
+        if len(parts) == 1:
+            etikedo = "ĉefa"
+            prima = True
+        else:
+            etikedo = parts[1]
+            prima = len(parts) >= 3 and parts[2].lower() in ("prima", "primary", "1", "jes")
+
+        if kind == "telefono" and not _PHONE_RE.match(value):
+            raise ValueError(
+                f"Phone number must start with country code (00...): {value!r}"
+            )
+        elif kind == "retposhto" and not _EMAIL_RE.match(value):
+            raise ValueError(f"Invalid email address: {value!r}")
+
+        out.append({"valoro": value, "etikedo": etikedo, "prima": prima})
+
+    # Enforce at most one primary
+    primary_indices = [i for i, item in enumerate(out) if item.get("prima")]
+    if len(primary_indices) > 1:
+        raise ValueError("Only one entry can be marked as primary.")
+    if out and not primary_indices:
+        out[0]["prima"] = True
+
+    return out
+
+
+# ── Display helpers ──────────────────────────────────────────────────────────
+
+
+def display_value(val: object) -> str:
+    """Format a profile value for human-readable display.
+
+    Handles lists, dicts, scalars, and URL rendering.
+
+    Args:
+        val: Raw profile value.
+
+    Returns:
+        Formatted string.
+    """
+    if val is None:
+        return "-"
+    if isinstance(val, list):
+        parts: list[str] = []
+        for item in val:
+            if isinstance(item, dict):
+                value = str(item.get("valoro", ""))
+                tag = str(item.get("etikedo", ""))
+                prima = bool(item.get("prima"))
+                suffix = " (prima)" if prima else ""
+                parts.append(f"{value} ({tag}){suffix}")
+            else:
+                parts.append(str(item))
+        return "; ".join(parts) if parts else "-"
+    if isinstance(val, dict):
+        return json.dumps(val, ensure_ascii=False)
+    return str(val)
+
+
+def mask_api_key(key: str | None) -> str:
+    """Mask an API key for display, showing only the last 4 characters.
+
+    Args:
+        key: The API key (or ``None``).
+
+    Returns:
+        Masked string like ``"••••abcd"``.
+    """
+    if not key:
+        return "-"
+    if len(key) > 4:
+        return "••••" + key[-4:]
+    return "••••"
+
+
+__all__ = [
+    "load_profile",
+    "save_profile",
+    "get_master_password",
+    "set_master_password",
+    "delete_master_password",
+    "get_huggingface_api_key",
+    "set_huggingface_api_key",
+    "delete_huggingface_api_key",
+    "encrypt_profile",
+    "decrypt_profile",
+    "validate_date",
+    "normalize_multi_contact",
+    "display_value",
+    "mask_api_key",
+    "_STANDARD_FIELDS",
+]

--- a/tests/test_uzanto.py
+++ b/tests/test_uzanto.py
@@ -1,0 +1,516 @@
+"""Tests for uzanto: config fix, service layer, and CLI commands."""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from A.core.testing import patch_paths
+
+runner = CliRunner()
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def isolate(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Redirect filesystem for every test; mock keyring module broadly."""
+    patch_paths(monkeypatch, tmp_path)
+    # Patch A.core.keyring module-level functions
+    monkeypatch.setattr("A.core.keyring.get_password", MagicMock(return_value=None))
+    monkeypatch.setattr("A.core.keyring.set_password", MagicMock(return_value=True))
+    monkeypatch.setattr("A.core.keyring.delete_password", MagicMock(return_value=True))
+
+
+@pytest.fixture
+def uzanto_app():
+    """Import the uzanto Typer app (lazy import to avoid side effects)."""
+    from A.core.uzanto_cli import app
+    return app
+
+
+@pytest.fixture(autouse=True)
+def set_language_to_eo(monkeypatch):
+    """Run CLI tests with Esperanto language for stable assertions."""
+    from A.core import i18n
+    i18n.set_language("eo")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# config.py — save_config() fix for settings dict
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_save_config_preserves_settings_dict():
+    """save_config() must persist a non-empty settings dict."""
+    from A.core.config import load_config, save_config
+
+    cfg = load_config()
+    cfg.settings["nomo"] = "Alice"
+    cfg.settings["aktivigo"] = True
+    cfg.settings["kalkulo"] = 42
+    save_config(cfg)
+
+    reloaded = load_config()
+    assert reloaded.settings.get("nomo") == "Alice"
+    assert reloaded.settings.get("aktivigo") is True
+    assert reloaded.settings.get("kalkulo") == 42
+
+
+def test_save_config_preserves_nested_settings():
+    """save_config() must persist lists and dicts inside settings."""
+    from A.core.config import load_config, save_config
+
+    cfg = load_config()
+    cfg.settings["lingvoj"] = ["eo", "en", "fr"]
+    cfg.settings["kontakto"] = {"telefono": "+123", "reta": "a@b.com"}
+    save_config(cfg)
+
+    reloaded = load_config()
+    assert reloaded.settings.get("lingvoj") == ["eo", "en", "fr"]
+    assert reloaded.settings.get("kontakto") == {"telefono": "+123", "reta": "a@b.com"}
+
+
+def test_save_config_roundtrip_empty_settings():
+    """save_config() with empty settings dict must not error."""
+    from A.core.config import load_config, save_config
+
+    cfg = load_config()
+    save_config(cfg)
+
+    reloaded = load_config()
+    assert isinstance(reloaded.settings, dict)
+    assert len(reloaded.settings) == 0
+
+
+def test_save_config_combined_fields():
+    """save_config() persists top-level fields alongside settings."""
+    from A.core.config import load_config, save_config
+
+    cfg = load_config()
+    cfg.language = "fr"
+    cfg.verbose = True
+    cfg.plugins = ["tempo", "vorto"]
+    cfg.aliases = {"g": "vorto serchi"}
+    cfg.settings["temo"] = "test"
+    save_config(cfg)
+
+    reloaded = load_config()
+    assert reloaded.language == "fr"
+    assert reloaded.verbose is True
+    assert "tempo" in reloaded.plugins
+    assert reloaded.aliases.get("g") == "vorto serchi"
+    assert reloaded.settings.get("temo") == "test"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# config.py — get_setting / set_setting helpers
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_get_setting_default():
+    """get_setting returns default for missing key."""
+    from A.core.config import get_setting
+    assert get_setting("nonexistent", "fallback") == "fallback"
+
+
+def test_get_setting_after_set():
+    """set_setting persists and get_setting retrieves."""
+    from A.core.config import get_setting, set_setting
+
+    set_setting("uzanto.nomo", "Bob")
+    assert get_setting("uzanto.nomo") == "Bob"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# uzanto_service.py — profile load / save
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_load_profile_empty():
+    """load_profile returns empty dict when no profile stored."""
+    from A.core.uzanto_service import load_profile
+    prof = load_profile()
+    assert isinstance(prof, dict)
+    assert len(prof) == 0
+
+
+def test_save_then_load_profile():
+    """save_profile followed by load_profile returns same data."""
+    from A.core.uzanto_service import load_profile, save_profile
+
+    data = {"nomo": "Alice", "lingvoj": ["eo", "en"]}
+    save_profile(data)
+    reloaded = load_profile()
+    assert reloaded["nomo"] == "Alice"
+    assert reloaded["lingvoj"] == ["eo", "en"]
+
+
+def test_save_profile_overwrites():
+    """save_profile replaces entire profile."""
+    from A.core.uzanto_service import load_profile, save_profile
+
+    save_profile({"nomo": "A", "a": 1})
+    save_profile({"nomo": "B"})
+    reloaded = load_profile()
+    assert reloaded["nomo"] == "B"
+    assert "a" not in reloaded
+
+
+# ── Keyring helpers ───────────────────────────────────────────────────────────
+
+
+@patch("A.core.uzanto_service.get_password", return_value="sekret123")
+def test_master_password_roundtrip(mock_get):
+    """set_master_password stores, get_master_password retrieves."""
+    from A.core.uzanto_service import get_master_password, set_master_password
+
+    set_master_password("sekret123")
+    assert get_master_password() == "sekret123"
+
+
+@patch("A.core.uzanto_service.get_password", return_value=None)
+def test_delete_master_password(mock_get):
+    """delete_master_password removes the password."""
+    from A.core.uzanto_service import get_master_password, set_master_password, delete_master_password
+
+    set_master_password("sekret123")
+    delete_master_password()
+    assert get_master_password() is None
+
+
+@patch("A.core.uzanto_service.get_password", return_value="hf_abc123")
+def test_huggingface_api_key_roundtrip(mock_get):
+    """set/get HuggingFace API key via keyring."""
+    from A.core.uzanto_service import get_huggingface_api_key, set_huggingface_api_key
+
+    set_huggingface_api_key("hf_abc123")
+    assert get_huggingface_api_key() == "hf_abc123"
+
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+
+def test_validate_date_valid():
+    from A.core.uzanto_service import validate_date
+    assert validate_date("2024-01-15") is True
+    assert validate_date("1999-12-31") is True
+    assert validate_date("0000-01-01") is True
+
+
+def test_validate_date_invalid():
+    from A.core.uzanto_service import validate_date
+    assert validate_date("24-01-15") is False
+    assert validate_date("2024/01/15") is False
+    assert validate_date("not-a-date") is False
+    assert validate_date("") is False
+    assert validate_date("2024-1-1") is False
+
+
+def test_normalize_multi_contact_phone():
+    from A.core.uzanto_service import normalize_multi_contact
+
+    items = ["003312345678:labo:prima"]
+    result = normalize_multi_contact(items, kind="telefono")
+    assert len(result) == 1
+    assert result[0]["valoro"] == "003312345678"
+    assert result[0]["etikedo"] == "labo"
+    assert result[0]["prima"] is True
+
+
+def test_normalize_multi_contact_email():
+    from A.core.uzanto_service import normalize_multi_contact
+
+    items = ["alice@example.com:hejma:prima", "bob@test.org:labo"]
+    result = normalize_multi_contact(items, kind="retposhto")
+    assert len(result) == 2
+    assert result[0]["prima"] is True
+    assert result[1]["prima"] is False
+
+
+def test_normalize_multi_contact_default_primary():
+    """Single item with no explicit primary defaults to primary."""
+    from A.core.uzanto_service import normalize_multi_contact
+
+    items = ["004412345678"]
+    result = normalize_multi_contact(items, kind="telefono")
+    assert result[0]["etikedo"] == "ĉefa"
+    assert result[0]["prima"] is True
+
+
+def test_normalize_multi_contact_two_primaries_raises():
+    from A.core.uzanto_service import normalize_multi_contact
+
+    items = ["003312345678:labo:prima", "004412345679:hejma:prima"]
+    with pytest.raises(ValueError, match="primary"):
+        normalize_multi_contact(items, kind="telefono")
+
+
+def test_normalize_multi_contact_invalid_phone():
+    from A.core.uzanto_service import normalize_multi_contact
+
+    with pytest.raises(ValueError, match="country code"):
+        normalize_multi_contact(["+12345"], kind="telefono")
+
+
+def test_normalize_multi_contact_invalid_email():
+    from A.core.uzanto_service import normalize_multi_contact
+
+    with pytest.raises(ValueError, match="Invalid email"):
+        normalize_multi_contact(["not-an-email"], kind="retposhto")
+
+
+# ── Display helpers ───────────────────────────────────────────────────────────
+
+
+def test_display_value_none():
+    from A.core.uzanto_service import display_value
+    assert display_value(None) == "-"
+
+
+def test_display_value_scalar():
+    from A.core.uzanto_service import display_value
+    assert display_value("hello") == "hello"
+    assert display_value(42) == "42"
+
+
+def test_display_value_list():
+    from A.core.uzanto_service import display_value
+    val = [{"valoro": "003312345678", "etikedo": "labo", "prima": True}]
+    result = display_value(val)
+    assert "003312345678" in result
+    assert "(labo)" in result
+    assert "(prima)" in result
+
+
+def test_display_value_empty_list():
+    from A.core.uzanto_service import display_value
+    assert display_value([]) == "-"
+
+
+def test_display_value_dict():
+    from A.core.uzanto_service import display_value
+    result = display_value({"key": "val"})
+    assert "key" in result
+    assert "val" in result
+
+
+def test_mask_api_key():
+    from A.core.uzanto_service import mask_api_key
+    assert mask_api_key(None) == "-"
+    assert mask_api_key("") == "-"
+    assert mask_api_key("abcd1234") == "••••1234"
+    assert mask_api_key("abcd12345678") == "••••5678"
+    assert mask_api_key("ab") == "••••"
+
+
+# ── Encryption roundtrip ──────────────────────────────────────────────────────
+
+
+def test_encrypt_decrypt_profile():
+    from A.core.uzanto_service import encrypt_profile, decrypt_profile
+
+    data = {"nomo": "Alice", "sekreta": "valoro"}
+    blob = encrypt_profile(data, "mypassword")
+    assert isinstance(blob, bytes)
+
+    decrypted = decrypt_profile(blob, "mypassword")
+    assert decrypted == data
+
+
+def test_decrypt_wrong_password():
+    from A.core.uzanto_service import encrypt_profile, decrypt_profile
+    from cryptography.exceptions import InvalidTag
+
+    data = {"x": 1}
+    blob = encrypt_profile(data, "correct")
+    with pytest.raises(InvalidTag):
+        decrypt_profile(blob, "wrong")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# uzanto_cli.py — CLI commands (Typer CliRunner)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def test_uzanto_vidi_empty(uzanto_app):
+    """A uzanto vidi should show default/empty state (no errors)."""
+    result = runner.invoke(uzanto_app, ["vidi"])
+    assert result.exit_code == 0
+    assert "eo" in result.stdout or "Lingvo" in result.stdout
+
+
+def test_uzanto_vidi_with_profile(uzanto_app):
+    """A uzanto vidi shows stored profile fields."""
+    from A.core.uzanto_service import save_profile
+    save_profile({"nomo": "Alice", "lingvoj": ["eo", "en"]})
+
+    result = runner.invoke(uzanto_app, ["vidi"])
+    assert result.exit_code == 0
+    assert "Alice" in result.stdout
+
+
+@patch("A.core.uzanto_service.set_password", return_value=True)
+def test_uzanto_modify_set_name(mock_set, uzanto_app):
+    """A uzanto modifi --nomo sets the name."""
+    result = runner.invoke(uzanto_app, ["modifi", "--nomo", "Alice"])
+    assert result.exit_code == 0
+
+    from A.core.uzanto_service import load_profile
+    prof = load_profile()
+    assert prof.get("nomo") == "Alice"
+
+
+def test_uzanto_modify_set_language(uzanto_app):
+    """A uzanto modifi --lingvo changes language."""
+    result = runner.invoke(uzanto_app, ["modifi", "--lingvo", "fr"])
+    assert result.exit_code == 0
+
+    from A.core.config import load_config
+    cfg = load_config()
+    assert cfg.language == "fr"
+
+
+def test_uzanto_modify_invalid_language(uzanto_app):
+    """A uzanto modifi with invalid language code should error."""
+    result = runner.invoke(uzanto_app, ["modifi", "--lingvo", "xyz"])
+    assert result.exit_code != 0
+
+
+def test_uzanto_modify_invalid_date(uzanto_app):
+    """A uzanto modifi with bad date should error."""
+    result = runner.invoke(uzanto_app, ["modifi", "--naskig-dato", "not-a-date"])
+    assert result.exit_code != 0
+
+
+@patch("A.core.uzanto_service.set_password", return_value=True)
+def test_uzanto_modify_custom_field(mock_set, uzanto_app):
+    """A uzanto modifi --kampo sets custom field."""
+    result = runner.invoke(uzanto_app, ["modifi", "--kampo", "koloro:verda"])
+    assert result.exit_code == 0
+
+    from A.core.uzanto_service import load_profile
+    prof = load_profile()
+    assert prof.get("kampoj", {}).get("koloro") == "verda"
+
+
+@patch("A.core.uzanto_service.set_password", return_value=True)
+def test_uzanto_modify_phone(mock_set, uzanto_app):
+    """A uzanto modifi --telefonnumero sets phone."""
+    result = runner.invoke(uzanto_app, ["modifi", "--telefonnumero", "003312345678:hejma:prima"])
+    assert result.exit_code == 0
+
+    from A.core.uzanto_service import load_profile
+    prof = load_profile()
+    phones = prof.get("telefonnumeroj", [])
+    assert len(phones) == 1
+    assert phones[0]["valoro"] == "003312345678"
+
+
+@patch("A.core.uzanto_service.set_password", return_value=True)
+def test_uzanto_modify_email(mock_set, uzanto_app):
+    """A uzanto modifi --retposhtadreso sets email."""
+    result = runner.invoke(uzanto_app, ["modifi", "--retposhtadreso", "a@b.com:labo:prima"])
+    assert result.exit_code == 0
+
+    from A.core.uzanto_service import load_profile
+    prof = load_profile()
+    emails = prof.get("retposhtadresoj", [])
+    assert len(emails) == 1
+    assert emails[0]["valoro"] == "a@b.com"
+
+
+@patch("A.core.uzanto_service.set_password", return_value=True)
+def test_uzanto_modify_multiple(mock_set, uzanto_app):
+    """A uzanto modifi with multiple options works."""
+    result = runner.invoke(uzanto_app, [
+        "modifi", "--nomo", "Charlie",
+        "--familia-nomo", "Brown",
+        "--lingvoj", "eo,en,fr",
+    ])
+    assert result.exit_code == 0
+
+    from A.core.uzanto_service import load_profile
+    prof = load_profile()
+    assert prof.get("nomo") == "Charlie"
+    assert prof.get("familia_nomo") == "Brown"
+    assert prof.get("lingvoj") == ["eo", "en", "fr"]
+
+
+def test_uzanto_export_plain(tmp_path, uzanto_app):
+    """A uzanto eksporti without encryption writes JSON."""
+    from A.core.uzanto_service import save_profile
+    save_profile({"nomo": "Alice"})
+
+    out = tmp_path / "profile.json"
+    result = runner.invoke(uzanto_app, ["eksporti", str(out)], input="n\n")
+    assert result.exit_code == 0
+    assert out.exists()
+
+    import json
+    data = json.loads(out.read_text("utf-8"))
+    assert data["profile"]["nomo"] == "Alice"
+
+
+def test_uzanto_export_encrypted(tmp_path, uzanto_app):
+    """A uzanto eksporti with --pasvorto writes encrypted file."""
+    from A.core.uzanto_service import save_profile, decrypt_profile
+    save_profile({"nomo": "Sekreto"})
+
+    out = tmp_path / "profile.enc"
+    result = runner.invoke(uzanto_app, ["eksporti", str(out), "--pasvorto", "sekret123"])
+    assert result.exit_code == 0
+    assert out.exists()
+
+    blob = out.read_bytes()
+    decrypted = decrypt_profile(blob, "sekret123")
+    assert decrypted["profile"]["nomo"] == "Sekreto"
+
+
+def test_uzanto_import_plain(tmp_path, uzanto_app):
+    """A uzanto importi reads plain JSON profile."""
+    data = {"language": "eo", "profile": {"nomo": "Bob"}}
+    src = tmp_path / "profile.json"
+    src.write_text(__import__("json").dumps(data), encoding="utf-8")
+
+    result = runner.invoke(uzanto_app, ["importi", str(src), "--anstatauigi"])
+    assert result.exit_code == 0
+
+    from A.core.uzanto_service import load_profile
+    prof = load_profile()
+    assert prof.get("nomo") == "Bob"
+
+
+def test_uzanto_import_missing_file(uzanto_app):
+    """A uzanto importi on nonexistent path should error."""
+    result = runner.invoke(uzanto_app, ["importi", "/nonexistent/path.json"])
+    assert result.exit_code != 0
+
+
+@patch("A.core.uzanto_service.get_password", return_value="sekret123")
+def test_uzanto_password_set_and_verify(mock_get, uzanto_app):
+    """A uzanto pasvorto sets the master password (mocked keyring)."""
+    from A.core.uzanto_service import get_master_password
+
+    result = runner.invoke(uzanto_app, ["pasvorto"], input="sekret123\nsekret123\nsekret123\n")
+    assert result.exit_code == 0
+
+    retrieved = get_master_password()
+    assert retrieved == "sekret123"
+
+
+def test_uzanto_password_too_short(uzanto_app):
+    """A uzanto pasvorto rejects short passwords."""
+    result = runner.invoke(uzanto_app, ["pasvorto"], input="ab\nab\n")
+    assert result.exit_code != 0
+
+
+def test_uzanto_helpo_shows_help(uzanto_app):
+    """A uzanto --helpo shows help text."""
+    result = runner.invoke(uzanto_app, ["--helpo"])
+    assert result.exit_code == 0
+    assert "uzanto" in result.stdout or "Administri" in result.stdout


### PR DESCRIPTION
## Summary

Ports autish-legacy `uzanto` profile commands and fixes P0 bug in `save_config()`.

Closes #17

## Changes

### Fix: `save_config()` drops settings dict (P0)
- **`config.py`**: rewrite `save_config()` with `tomlkit` to properly serialize nested `settings` dict (lists, dicts, scalars)
- **`config.py`**: `load_config()` reads from `[A]` section (supports both legacy top-level and new format)

### New: `uzanto_service.py` service layer
- Profile CRUD (load/save to config settings)
- Keyring-backed master password + HuggingFace API key
- Encrypted profile export/import (`encrypt_profile`/`decrypt_profile`)
- Validation: date (YYYY-MM-DD), phone (00-prefixed), email
- Display helpers: `display_value`, `mask_api_key`
- Structured multi-contact fields (`telefonnumeroj`, `retposhtadresoj`)

### Rewritten: `uzanto_cli.py`
All commands from autish-legacy, plus new fields:
- `vidi` — rich table display
- `modifi` — all profile fields including custom `kampoj`
- `eksporti` — plain or AES-256-GCM encrypted JSON
- `importi` — plain or encrypted import
- `pasvorto` — set/remove master password with `--forigi`
- `--helpo` i18n help in eo/en/fr

### Tests: `test_uzanto.py` (45 passing)
- Config roundtrip (top-level fields + nested settings)
- Service layer (profile, keyring, validation, display, encryption)
- CLI commands (vidi, modifi, eksporti, importi, pasvorto)

## Testing
```
$ uv run pytest tests/test_uzanto.py -v
45 passed
```
Full suite: 355 passed, 1 skipped (network-dependent test)