### PR TITLE
feat: add file_security module (resolve_safe_path, match_path_globs, PathTraversalError)

### DIFF
--- a/src/A/core/ai_config.py
+++ b/src/A/core/ai_config.py
@@ -1,0 +1,37 @@
+"""Minimal provider configuration for A-kunpiloto.
+
+Provides ``get_configured_provider`` used by :mod:`A_kunpiloto.cli`.
+
+Full implementation lives in the ``feat/ai-config-abstraction`` branch.
+This is a minimal shim so A-kunpiloto can import and function.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from A.core.ai import get_provider
+
+
+def get_configured_provider(
+    ref: str | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Resolve a provider reference to an ``LLMProvider`` instance.
+
+    This is a thin shim over :func:`A.core.ai.get_provider` that
+    accepts a provider name or ``None`` (falls back to "openai").
+
+    Args:
+        ref: Provider name (``"openai"``, ``"deepseek"``, ``"ollama"``)
+            or ``None`` for auto-fallback.
+        **kwargs: Passed to the provider constructor.
+
+    Returns:
+        ``LLMProvider`` instance.
+
+    Raises:
+        ValueError: If the provider type is unknown.
+    """
+    provider_type = ref or "openai"
+    return get_provider(provider_type, **kwargs)

--- a/src/A/core/exceptions.py
+++ b/src/A/core/exceptions.py
@@ -1,5 +1,7 @@
 """Base exceptions for A."""
 
+from __future__ import annotations
+
 from typing import Any
 
 
@@ -53,4 +55,22 @@ class ProtectedPathError(AError):
             f"Cannot {operation} protected path: {path}. "
             f"Remove the '.a-protected' marker file first "
             f"if you are sure."
+        )
+
+
+class PathTraversalError(AError):
+    """Raised when a file path escapes all allowed base directories.
+
+    Used by :func:`A.core.file_security.resolve_safe_path` when a
+    resolved path does not fall within any of the configured allowlist
+    base directories.
+    """
+
+    def __init__(self, path: str, allowed_bases: "list[str]" | None = None):
+        self.path = path
+        self.allowed_bases = allowed_bases or []
+        bases_str = ", ".join(self.allowed_bases) if self.allowed_bases else "(none)"
+        super().__init__(
+            f"Path traversal detected: '{path}' is not under any allowed "
+            f"base directory ({bases_str})."
         )

--- a/src/A/core/file_security.py
+++ b/src/A/core/file_security.py
@@ -1,0 +1,270 @@
+"""File path security utilities for the A-ecosystem.
+
+Provides path resolution with traversal detection and glob-pattern
+matching. Designed for use by A-kunpiloto's built-in file tools
+(``write_file``, ``read_file``) and reusable by any A-module that
+needs to validate user-supplied file paths against an allowlist.
+
+Usage::
+
+    from A.core.file_security import resolve_safe_path, match_path_globs
+
+    bases = [Path("/tmp/A"), Path.home() / "Documents"]
+    try:
+        p = resolve_safe_path("~/Documents/note.md", *bases)
+        # p -> PosixPath('/home/user/Documents/note.md')
+    except PathTraversalError:
+        # path escapes all allowed bases
+        ...
+
+    allowed = ["/tmp/A/**", "~/Desktop/*"]
+    if match_path_globs(p, allowed):
+        # path matches an allowlist pattern
+        ...
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+from pathlib import Path
+from typing import Sequence
+
+from A.core.exceptions import PathTraversalError
+
+__all__ = ["resolve_safe_path", "match_path_globs"]
+
+
+def resolve_safe_path(
+    path: str | Path,
+    *allowed_bases: Path,
+) -> Path:
+    """Resolve a user-supplied path and verify it is within allowed bases.
+
+    Steps:
+    1. Expand ``~`` to the user's home directory.
+    2. Resolve symlinks (``Path.resolve()`` gives the real path).
+    3. Verify the resolved path is contained within at least one of the
+       *allowed_bases*.
+
+    Args:
+        path: The raw path from user input (may contain ``~``, ``..``,
+            symlinks, or relative components).
+        *allowed_bases: One or more base directories that are considered
+            safe. The resolved path must be inside at least one of these.
+
+    Returns:
+        The resolved, absolute :class:`Path`.
+
+    Raises:
+        PathTraversalError: If the resolved path escapes every allowed
+            base directory.
+
+    Example::
+
+        >>> resolve_safe_path("~/foo", Path.home())
+        PosixPath('/home/user/foo')
+
+        >>> resolve_safe_path("/etc/passwd", Path.home())
+        PathTraversalError: /etc/passwd is not under any allowed base
+    """
+    expanded = Path(path).expanduser()
+
+    # Resolve relative paths against CWD, then resolve symlinks
+    if not expanded.is_absolute():
+        expanded = (Path.cwd() / expanded).resolve()
+    else:
+        expanded = expanded.resolve()
+
+    _validate_within_allowed(expanded, allowed_bases)
+    return expanded
+
+
+def match_path_globs(path: Path, patterns: Sequence[str]) -> bool:
+    """Check whether *path* matches any of the given glob patterns.
+
+    Supports the following pattern forms:
+
+    - ``/path/to/dir/**`` — recursively matches everything under ``dir``.
+    - ``/path/to/dir/*`` — matches files directly inside ``dir``.
+    - ``/path/to/file`` — exact file match.
+    - ``**/file`` — matches ``file`` at any depth (relative wildcard).
+    - ``~`` is expanded before matching.
+
+    Args:
+        path: The absolute path to check.
+        patterns: A list of glob patterns (e.g. ``["/tmp/A/**", "~/Docs/*"]``).
+
+    Returns:
+        ``True`` if *path* matches at least one pattern.
+
+    Example::
+
+        >>> match_path_globs(Path("/tmp/A/foo/bar.txt"), ["/tmp/A/**"])
+        True
+
+        >>> match_path_globs(Path("/etc/passwd"), ["/tmp/A/**"])
+        False
+    """
+    for pattern in patterns:
+        raw = pattern.strip()
+        if not raw:
+            continue
+
+        # Expand ~ in the pattern
+        pat = os.path.expanduser(raw)
+
+        if _match_single_pattern(path, pat):
+            return True
+
+    return False
+
+
+def _match_single_pattern(path: Path, pattern: str) -> bool:
+    """Check if *path* matches a single glob pattern.
+
+    This is an internal helper that implements the matching logic
+    without relying on PurePath.match (which has poor support for
+    ``**`` in absolute patterns).
+    """
+    # 1. Recursive wildcard: /** at pattern end
+    #    /tmp/A/**  matches /tmp/A itself and /tmp/A/anything/deeply/nested
+    if pattern.endswith("/**"):
+        base = Path(pattern[:-3])
+        if path == base or _path_is_under(path, base):
+            return True
+
+    # 2. Shallow wildcard: /* at pattern end
+    #    /tmp/A/*  matches /tmp/A/foo but NOT /tmp/A/sub/bar
+    if pattern.endswith("/*"):
+        base = Path(pattern[:-2])
+        if path.parent == base:
+            return True
+
+    # 3. Exact match
+    if path == Path(pattern):
+        return True
+
+    # 4. fnmatch on last component only (prevents * from crossing /)
+    #    /tmp/A/foo*.txt  matches /tmp/A/foo123.txt but not /tmp/A/sub/bar.txt
+    pattern_path = Path(pattern)
+    if pattern_path.parent == path.parent:
+        if fnmatch.fnmatch(path.name, pattern_path.name):
+            return True
+
+    # 5. ** recursion anywhere in the pattern
+    #    **/file.txt  matches /home/user/any/path/file.txt
+    #    /tmp/**/foo.txt  matches /tmp/a/b/foo.txt
+    if "**" in pattern:
+        parts = pattern_path.parts
+        if _match_recursive_parts(path, parts):
+            return True
+
+    return False
+
+
+def _path_is_under(path: Path, base: Path) -> bool:
+    """Check if *path* is under *base* directory (recursive)."""
+    try:
+        path.relative_to(base)
+        return True
+    except ValueError:
+        return False
+
+
+def _match_recursive_parts(path: Path, pattern_parts: tuple[str, ...]) -> bool:
+    """Match a path against a pattern that contains ``**``.
+
+    Splits on ``**`` and verifies each segment matches in order.
+    """
+    # Split pattern into segments around **
+    segments: list[tuple[str, ...]] = []
+    current: list[str] = []
+    for part in pattern_parts:
+        if part == "**":
+            if current:
+                segments.append(tuple(current))
+                current = []
+            # Represent ** as a sentinel
+            segments.append(("__DOUBLESTAR__",))
+        else:
+            current.append(part)
+    if current:
+        segments.append(tuple(current))
+
+    path_parts = path.parts
+
+    return _match_segments(path_parts, 0, segments, 0)
+
+
+def _match_segments(
+    path_parts: tuple[str, ...],
+    pi: int,
+    segments: list[tuple[str, ...]],
+    si: int,
+) -> bool:
+    """Recursively match path parts against pattern segments.
+
+    Args:
+        path_parts: The path split into parts.
+        pi: Current index in path_parts.
+        segments: The parsed pattern segments.
+        si: Current index in segments.
+
+    Returns:
+        True if the remaining path matches the remaining segments.
+    """
+    # Base case: consumed all segments
+    if si >= len(segments):
+        return pi >= len(path_parts)
+
+    seg = segments[si]
+
+    # ** segment: try matching 0 or more path components
+    if seg == ("__DOUBLESTAR__",):
+        # Try consuming 0, 1, 2, ... path parts
+        for skip in range(len(path_parts) - pi + 1):
+            if _match_segments(path_parts, pi + skip, segments, si + 1):
+                return True
+        return False
+
+    # Regular segment: must match the next N path parts exactly
+    if pi + len(seg) > len(path_parts):
+        return False
+
+    for i, part in enumerate(seg):
+        if not fnmatch.fnmatch(path_parts[pi + i], part):
+            return False
+
+    return _match_segments(path_parts, pi + len(seg), segments, si + 1)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_within_allowed(
+    resolved: Path,
+    allowed_bases: Sequence[Path],
+) -> None:
+    """Check that *resolved* is inside at least one allowed base.
+
+    Raises:
+        PathTraversalError: If the path escapes every allowed base.
+    """
+    for base in allowed_bases:
+        base_resolved = base.expanduser().resolve()
+        try:
+            resolved.relative_to(base_resolved)
+            return  # Safe — path is under this base
+        except ValueError:
+            continue
+
+    # Check if the path equals an allowed base exactly
+    for base in allowed_bases:
+        base_resolved = base.expanduser().resolve()
+        if resolved == base_resolved:
+            return
+
+    raise PathTraversalError(str(resolved), [str(b) for b in allowed_bases])

--- a/tests/test_file_security.py
+++ b/tests/test_file_security.py
@@ -1,0 +1,208 @@
+"""Tests for A.core.file_security."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from A.core.exceptions import PathTraversalError
+from A.core.file_security import (
+    match_path_globs,
+    resolve_safe_path,
+)
+
+
+class TestResolveSafePath:
+    """Unit tests for resolve_safe_path()."""
+
+    def test_absolute_path_within_allowed(self, tmp_path: Path) -> None:
+        """An absolute path inside an allowed base resolves successfully."""
+        target = tmp_path / "subdir" / "file.txt"
+        target.parent.mkdir(parents=True)
+        target.write_text("hello")
+
+        result = resolve_safe_path(str(target), tmp_path)
+        assert result == target.resolve()
+
+    def test_tilde_expansion(self, tmp_path: Path) -> None:
+        """~ is expanded to the user's home directory."""
+        home = Path.home()
+        # We need a path that actually exists under home
+        allowed = home
+        target = home / ".bashrc"
+        if not target.exists():
+            target = home / ".bash_logout"
+        if not target.exists():
+            target = home / ".profile"
+        # If none of those exist, use home itself
+        result = resolve_safe_path(str(target), allowed)
+        assert result == target.resolve()
+
+    def test_path_traversal_rejected(self, tmp_path: Path) -> None:
+        """A path that escapes the allowed base raises PathTraversalError."""
+        allowed = tmp_path / "allowed"
+        allowed.mkdir(parents=True)
+        target = tmp_path / "secret.txt"
+        target.write_text("secret")
+
+        # Try to reference secret.txt via relative traversal from allowed
+        with pytest.raises(PathTraversalError):
+            resolve_safe_path(str(target), allowed)
+
+    def test_path_outside_allowed_raises(self, tmp_path: Path) -> None:
+        """A path obviously outside the allowed base raises."""
+        allowed = tmp_path / "safe"
+        allowed.mkdir()
+        target = tmp_path / "outside" / "file.txt"
+        target.parent.mkdir()
+        target.write_text("data")
+
+        with pytest.raises(PathTraversalError):
+            resolve_safe_path(str(target), allowed)
+
+    def test_multiple_allowed_bases(self, tmp_path: Path) -> None:
+        """Path inside ANY of the allowed bases is accepted."""
+        base_a = tmp_path / "a"
+        base_b = tmp_path / "b"
+        base_a.mkdir()
+        base_b.mkdir()
+
+        target_b = base_b / "file.txt"
+        target_b.write_text("ok")
+
+        result = resolve_safe_path(str(target_b), base_a, base_b)
+        assert result == target_b.resolve()
+
+    def test_exact_allowed_base(self, tmp_path: Path) -> None:
+        """The allowed base directory itself is a valid target."""
+        allowed = tmp_path / "safe"
+        allowed.mkdir()
+
+        result = resolve_safe_path(str(allowed), allowed)
+        assert result == allowed.resolve()
+
+    def test_symlink_outside_rejected(self, tmp_path: Path) -> None:
+        """A symlink pointing outside the allowed base is rejected."""
+        allowed = tmp_path / "safe"
+        allowed.mkdir()
+
+        outside = tmp_path / "outside.txt"
+        outside.write_text("secret")
+
+        link = allowed / "link.txt"
+        link.symlink_to(outside)
+
+        with pytest.raises(PathTraversalError):
+            resolve_safe_path(str(link), allowed)
+
+    def test_nonexistent_path_inside_allowed(self, tmp_path: Path) -> None:
+        """A path that doesn't exist yet but is within allowed base works."""
+        allowed = tmp_path / "safe"
+        allowed.mkdir()
+        future = allowed / "newfile.txt"
+
+        # resolve_safe_path should succeed even if file doesn't exist
+        # (the check is about directory containment, not file existence)
+        result = resolve_safe_path(str(future), allowed)
+        assert result == future.resolve()
+        assert not result.exists()
+
+    def test_relative_path_resolved_against_cwd(self, tmp_path: Path) -> None:
+        """A relative path is resolved against CWD."""
+        allowed = tmp_path / "safe"
+        allowed.mkdir()
+        target = allowed / "file.txt"
+        target.write_text("data")
+
+        old_cwd = Path.cwd()
+        try:
+            os.chdir(str(tmp_path))
+            # Relative path: safe/file.txt
+            result = resolve_safe_path("safe/file.txt", allowed)
+            assert result == target.resolve()
+        finally:
+            os.chdir(str(old_cwd))
+
+
+class TestMatchPathGlobs:
+    """Unit tests for match_path_globs()."""
+
+    def test_exact_match(self) -> None:
+        """Exact pattern matches."""
+        assert match_path_globs(Path("/tmp/foo.txt"), ["/tmp/foo.txt"])
+
+    def test_wildcard_star(self) -> None:
+        """* matches anything in the same directory."""
+        assert match_path_globs(Path("/tmp/foo.txt"), ["/tmp/*"])
+        assert not match_path_globs(Path("/tmp/sub/foo.txt"), ["/tmp/*"])
+
+    def test_double_star(self) -> None:
+        """** matches any depth recursively."""
+        assert match_path_globs(Path("/tmp/a/b/c/file.txt"), ["/tmp/**"])
+        assert match_path_globs(Path("/tmp/file.txt"), ["/tmp/**"])
+
+    def test_tilde_in_pattern(self) -> None:
+        """~ is expanded in patterns."""
+        home = Path.home()
+        assert match_path_globs(home / "doc.txt", ["~/doc.txt"])
+
+    def test_no_match(self) -> None:
+        """Return False when no pattern matches."""
+        assert not match_path_globs(Path("/etc/passwd"), ["/tmp/**"])
+
+    def test_multiple_patterns_second_matches(self) -> None:
+        """Second pattern catches the path."""
+        assert match_path_globs(
+            Path("/var/log/syslog"),
+            ["/tmp/**", "/var/**"],
+        )
+
+    def test_empty_patterns(self) -> None:
+        """Empty patterns list returns False."""
+        assert not match_path_globs(Path("/tmp/foo.txt"), [])
+
+    def test_empty_string_pattern(self) -> None:
+        """Empty string in patterns is ignored."""
+        assert not match_path_globs(Path("/tmp/foo.txt"), [""])
+
+    def test_question_mark(self) -> None:
+        """? matches a single character."""
+        assert match_path_globs(Path("/tmp/foo.txt"), ["/tmp/fo?.txt"])
+        assert not match_path_globs(Path("/tmp/foo.txt"), ["/tmp/fo?.md"])
+
+    def test_pattern_with_trailing_slash(self) -> None:
+        """Patterns with trailing slash work (trailing slash is treated as part of path)."""
+        assert match_path_globs(Path("/tmp/foo.txt"), ["/tmp/*"])
+        # Without trailing slash ** is the canonical form
+        assert match_path_globs(Path("/tmp/foo.txt"), ["/tmp/**"])
+
+    def test_path_with_dot(self) -> None:
+        """Dot files are matched normally."""
+        assert match_path_globs(Path("/tmp/.hidden"), ["/tmp/*"])
+
+    def test_relative_pattern(self) -> None:
+        """Relative patterns match against the full path."""
+        assert match_path_globs(Path("/home/user/doc.md"), ["**/doc.md"])
+
+
+class TestPathTraversalError:
+    """Unit tests for the PathTraversalError exception."""
+
+    def test_error_message_contains_path(self) -> None:
+        """Error message includes the rejected path."""
+        err = PathTraversalError("/etc/passwd", ["/tmp/A"])
+        assert "/etc/passwd" in str(err)
+        assert "/tmp/A" in str(err)
+
+    def test_error_message_without_bases(self) -> None:
+        """Error message works with no allowed bases."""
+        err = PathTraversalError("/etc/passwd")
+        assert "(none)" in str(err)
+
+    def test_is_aerror_subclass(self) -> None:
+        """PathTraversalError inherits from AError."""
+        from A.core.exceptions import AError
+
+        assert issubclass(PathTraversalError, AError)


### PR DESCRIPTION
Add `A.core.file_security` module with path-resolution and glob-matching utilities for A-kunpiloto upcoming `write_file`/`read_file` built-in tools.

### API

- `resolve_safe_path(path, *allowed_bases)` — normalise, resolve symlinks, detect path traversal
- `match_path_globs(path, patterns)` — match paths against glob patterns (`*`, `**`, `?`)
- `PathTraversalError` — new exception in `A.core.exceptions`

Also adds a minimal `ai_config.py` shim providing `get_configured_provider()` (wraps `A.core.ai.get_provider()`) needed by A-kunpiloto.

Closes A-core#104
Depends on: A-kunpiloto#14